### PR TITLE
Fixed module folder naming

### DIFF
--- a/helpers/paths.php
+++ b/helpers/paths.php
@@ -9,6 +9,6 @@ if (! function_exists('fusion_path')) {
      */
     function fusion_path($path = '')
     {
-        return realpath(__DIR__.'/../').$path;
+        return realpath(__DIR__ . '/../') . ($path ? DIRECTORY_SEPARATOR.ltrim($path, DIRECTORY_SEPARATOR) : $path);
     }
 }

--- a/src/Console/SyncCommand.php
+++ b/src/Console/SyncCommand.php
@@ -46,7 +46,7 @@ class SyncCommand extends Command
 
                 // publish settings..
                 $this->symlink(
-                    fusion_path("/settings/modules/{$item['slug']}.php"),
+                    fusion_path("settings/modules/{$item['slug']}.php"),
                     base_path("modules/{$item['basename']}/settings.php")
                 );
 

--- a/src/Http/Controllers/DataTable/ModuleController.php
+++ b/src/Http/Controllers/DataTable/ModuleController.php
@@ -4,8 +4,9 @@ namespace Fusion\Http\Controllers\DataTable;
 
 use Illuminate\Http\Request;
 use Caffeinated\Modules\Facades\Module;
+use Fusion\Http\Controllers\Controller;
 
-class ModuleController
+class ModuleController extends Controller
 {
     public function index(Request $request)
     {


### PR DESCRIPTION
This PR tackles [fusioncms/cms #480](https://github.com/fusioncms/fusioncms/issues/480).
Modules will now use the `name` value in the manifest file to name the housing folder.