### PR TITLE
Reference full facade namespace path

### DIFF
--- a/src/Http/Controllers/API/ActiveThemeController.php
+++ b/src/Http/Controllers/API/ActiveThemeController.php
@@ -2,7 +2,7 @@
 
 namespace Fusion\Http\Controllers\API;
 
-use Theme;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\Controller;
 use Fusion\Http\Resources\ThemeResource;
 

--- a/src/Http/Controllers/API/LogsController.php
+++ b/src/Http/Controllers/API/LogsController.php
@@ -2,10 +2,10 @@
 
 namespace Fusion\Http\Controllers\API;
 
-use Theme;
 use Illuminate\Http\Request;
-use Fusion\Http\Controllers\Controller;
 use Fusion\Services\Logs\Repository;
+use Caffeinated\Themes\Facades\Theme;
+use Fusion\Http\Controllers\Controller;
 
 class LogsController extends Controller
 {

--- a/src/Http/Controllers/API/Themes/ActiveController.php
+++ b/src/Http/Controllers/API/Themes/ActiveController.php
@@ -2,8 +2,8 @@
 
 namespace Fusion\Http\Controllers\API\Themes;
 
-use Theme;
 use Illuminate\Http\Request;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\Controller;
 use Fusion\Http\Resources\ThemeResource;
 

--- a/src/Http/Controllers/API/Themes/BrowseController.php
+++ b/src/Http/Controllers/API/Themes/BrowseController.php
@@ -2,12 +2,12 @@
 
 namespace Fusion\Http\Controllers\API\Themes;
 
-use Theme;
 use Storage;
 use Artisan;
 use ZipArchive;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\Controller;
 use Fusion\Http\Resources\ThemeResource;
 use Fusion\Http\Requests\StoreThemeRequest;

--- a/src/Http/Controllers/API/Themes/VerifyController.php
+++ b/src/Http/Controllers/API/Themes/VerifyController.php
@@ -2,10 +2,10 @@
 
 namespace Fusion\Http\Controllers\API\Themes;
 
-use Theme;
 use Storage;
 use ZipArchive;
 use Illuminate\Http\Request;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\Controller;
 use Fusion\Http\Requests\VerifyThemeRequest;
 

--- a/src/Http/Controllers/DataTable/MailableController.php
+++ b/src/Http/Controllers/DataTable/MailableController.php
@@ -3,9 +3,9 @@
 namespace Fusion\Http\Controllers\DataTable;
 
 use File;
-use Theme;
 use ReflectionClass;
 use Fusion\Models\Mailable;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\DataTableController;
 
 class MailableController extends DataTableController

--- a/src/Http/Controllers/Web/Themes/ScreenshotController.php
+++ b/src/Http/Controllers/Web/Themes/ScreenshotController.php
@@ -2,7 +2,7 @@
 
 namespace Fusion\Http\Controllers\Web\Themes;
 
-use Theme;
+use Caffeinated\Themes\Facades\Theme;
 use Fusion\Http\Controllers\Controller;
 use Fusion\Http\Resources\ThemeResource;
 

--- a/src/Http/Resources/ThemeResource.php
+++ b/src/Http/Resources/ThemeResource.php
@@ -2,7 +2,7 @@
 
 namespace Fusion\Http\Resources;
 
-use Theme;
+use Caffeinated\Themes\Facades\Theme;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class ThemeResource extends JsonResource

--- a/src/Rules/UniqueThemeName.php
+++ b/src/Rules/UniqueThemeName.php
@@ -3,9 +3,9 @@
 namespace Fusion\Rules;
 
 use Log;
-use Theme;
 use Exception;
 use ZipArchive;
+use Caffeinated\Themes\Facades\Theme;
 use Illuminate\Contracts\Validation\Rule;
 
 class UniqueThemeName implements Rule


### PR DESCRIPTION
For some reason, not able to simply reference the `Theme` facade without referencing the full namespace path (it should be auto-discovered by composer/laravel).

Referencing the full path resolves this issue in the meantime.