### PR TITLE
Error: Failed to install on laravel project

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -140,7 +140,7 @@ class InstallCommand extends Command
             unset(
                 $jobs['Deleting environment config...'],
                 $jobs['Creating environment config...'],
-                $jobs['Generating encryption key...'],
+                $jobs['Generating encryption key...']
             );
         }
 


### PR DESCRIPTION
There was an extra comma causing the installtion to fail.