### PR TITLE
Issue 493

### DIFF
--- a/src/Concerns/HasActivity.php
+++ b/src/Concerns/HasActivity.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Fusion\Concerns;
+
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+trait HasActivity
+{
+	use LogsActivity;
+
+	/**
+	 * Limit event logging to..
+	 * 
+	 * @var array
+	 */
+	protected static $recordEvents = ['created', 'updated'];
+
+	/**
+	 * Clean up on `deleted` event.
+	 * 
+	 * @return void
+	 */
+	protected static function bootHasActivity()
+	{
+		static::deleted(function ($model) {
+			Activity::where([
+				'subject_id'   => $model->id,
+				'subject_type' => get_class($model)
+			])->get()->each(function($record) {
+				$record->delete();
+			});
+		});
+	}
+}

--- a/src/Models/Directory.php
+++ b/src/Models/Directory.php
@@ -2,13 +2,13 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Directory extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
     /**
      * Fillable fields for Directory model.

--- a/src/Models/Fieldset.php
+++ b/src/Models/Fieldset.php
@@ -2,14 +2,14 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
 use Fusion\Concerns\HasDynamicRelationships;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Fieldset extends Model
 {
-    use HasDynamicRelationships, LogsActivity;
+    use HasDynamicRelationships, HasActivity;
 
     /**
      * The attributes that are fillable via mass assignment.
@@ -103,11 +103,10 @@ class Fieldset extends Model
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'list'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "fieldsets/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "fieldsets/{$subject->id}/edit",
+            'icon' => 'list'
+        ];
 
         $activity->description = "{$action} fieldset ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -2,15 +2,15 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Concerns\HasFieldset;
 use Fusion\Concerns\CachesQueries;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Form extends Model
 {
-    use CachesQueries, HasFieldset, LogsActivity;
+    use CachesQueries, HasFieldset, HasActivity;
 
     protected $with = ['fieldsets'];
 
@@ -118,11 +118,10 @@ class Form extends Model
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'paper-plane'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "forms/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "forms/{$subject->id}/edit",
+            'icon' => 'paper-plane'
+        ];
 
         $activity->description = "{$action} form ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/Import.php
+++ b/src/Models/Import.php
@@ -2,13 +2,13 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Import extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
     /**
      * The attributes that are fillable via mass assignment.
@@ -63,11 +63,10 @@ class Import extends Model
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'ship'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "importer/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "importer/{$subject->id}/edit",
+            'icon' => 'ship'
+        ];
 
         $activity->description = "{$action} import ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/Mailable.php
+++ b/src/Models/Mailable.php
@@ -8,16 +8,16 @@ use ReflectionClass;
 use ReflectionProperty;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Illuminate\Support\Collection;
 use Caffeinated\Themes\Facades\Theme;
 use Spatie\Activitylog\Models\Activity;
 use Illuminate\Database\Eloquent\Model;
 use Fusion\Models\Mailable as MailableModel;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Mailable extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
 	/**
      * The attributes that are fillable via mass assignment.
@@ -184,13 +184,15 @@ class Mailable extends Model
      */
     public function tapActivity(Activity $activity, string $eventName)
     {
-        $subject = $activity->subject;
-        $action  = ucfirst($eventName);
+        if ($eventName == 'updated') {
+            $subject = $activity->subject;
+            $action  = ucfirst($eventName);
 
-        $activity->description = "{$action} mailable ({$subject->name})";
-        $activity->properties  = [
-            'icon' => 'mail-bulk',
-            'link' => "mailables/{$subject->id}/edit"
-        ];
+            $activity->description = "{$action} mailable ({$subject->name})";
+            $activity->properties  = [
+                'icon' => 'mail-bulk',
+                'link' => "mailables/{$subject->id}/edit"
+            ];
+        }
     }
 }

--- a/src/Models/Mailable.php
+++ b/src/Models/Mailable.php
@@ -167,14 +167,7 @@ class Mailable extends Model
             }
         }
     }
-
-    /**
-     * Just log update event.
-     *
-     * @var array
-     */
-    protected static $recordEvents = ['updated'];
-
+    
     /**
      * Tap into activity before persisting to database.
      *

--- a/src/Models/Matrix.php
+++ b/src/Models/Matrix.php
@@ -3,15 +3,15 @@
 namespace Fusion\Models;
 
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Concerns\HasFieldset;
 use Fusion\Concerns\CachesQueries;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Matrix extends Model
 {
-    use CachesQueries, HasFieldset, LogsActivity;
+    use CachesQueries, HasFieldset, HasActivity;
 
     protected $with = ['fieldsets'];
 
@@ -106,11 +106,10 @@ class Matrix extends Model
     {
         $matrix     = $activity->subject;
         $action     = Str::ucfirst($eventName);
-        $properties = ['icon' => 'hashtag'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "matrices/{$matrix->id}/edit";
-        }
+        $properties = [
+            'icon' => 'hashtag',
+            'link' => "matrices/{$matrix->id}/edit"
+        ];
 
         $activity->description = "{$action} matrix ({$matrix->name})";
         $activity->properties  = $properties;

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -2,15 +2,15 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Concerns\HasFieldset;
 use Fusion\Concerns\CachesQueries;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Menu extends Model
 {
-    use CachesQueries, HasFieldset, LogsActivity;
+    use CachesQueries, HasFieldset, HasActivity;
 
     protected $with = ['fieldsets'];
 
@@ -73,11 +73,10 @@ class Menu extends Model
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'anchor'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "menus/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "menus/{$subject->id}/edit",
+            'icon' => 'anchor'
+        ];
 
         $activity->description = "{$action} menu ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -2,16 +2,16 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 use Caffeinated\Shinobi\Concerns\HasPermissions;
 use Caffeinated\Shinobi\Contracts\Role as RoleContract;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Role extends Model implements RoleContract
 {
-    use HasPermissions, LogsActivity;
+    use HasPermissions, HasActivity;
 
     /**
      * The attributes that are fillable via mass assignment.
@@ -67,11 +67,10 @@ class Role extends Model implements RoleContract
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'id-badge'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "roles/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "roles/{$subject->id}/edit",
+            'icon' => 'id-badge'
+        ];
 
         $activity->description = "{$action} user role ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -2,14 +2,14 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Fusion\Concerns\CachesQueries;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Setting extends Model
 {
-    use CachesQueries, LogsActivity;
+    use CachesQueries, HasActivity;
 
     /**
      * The attributes that are guarded via mass assignment.
@@ -54,13 +54,6 @@ class Setting extends Model
     }
 
     /**
-     * Just log update event.
-     *
-     * @var array
-     */
-    protected static $recordEvents = ['updated'];
-
-    /**
      * Tap into activity before persisting to database.
      *
      * @param  \Spatie\Activitylog\Models\Activity $activity
@@ -69,14 +62,16 @@ class Setting extends Model
      */
     public function tapActivity(Activity $activity, string $eventName)
     {
-        $setting = $activity->subject;
-        $section = $setting->section;
-        $action  = ucfirst($eventName);
+        if ($eventName == 'updated') {
+            $setting = $activity->subject;
+            $section = $setting->section;
+            $action  = ucfirst($eventName);
 
-        $activity->description = "{$action} {$section->name} settings";
-        $activity->properties  = [
-            'icon' => 'cog',
-            'link' => 'settings'
-        ];
+            $activity->description = "{$action} {$section->name} settings";
+            $activity->properties  = [
+                'icon' => 'cog',
+                'link' => 'settings'
+            ];
+        }
     }
 }

--- a/src/Models/Taxonomy.php
+++ b/src/Models/Taxonomy.php
@@ -3,15 +3,15 @@
 namespace Fusion\Models;
 
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Concerns\HasFieldset;
 use Fusion\Concerns\CachesQueries;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class Taxonomy extends Model
 {
-    use CachesQueries, HasFieldset, LogsActivity;
+    use CachesQueries, HasFieldset, HasActivity;
 
     protected $with = ['fieldsets'];
 
@@ -107,11 +107,10 @@ class Taxonomy extends Model
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'sitemap'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "taxonomies/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "taxonomies/{$subject->id}/edit",
+            'icon' => 'sitemap'
+        ];
 
         $activity->description = "{$action} taxonomy ({$subject->name})";
         $activity->properties  = $properties;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,12 +2,12 @@
 
 namespace Fusion\Models;
 
+use Fusion\Concerns\HasActivity;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Notifications\Notifiable;
 use Fusion\Concerns\HasDynamicRelationships;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\Traits\CausesActivity;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -21,7 +21,7 @@ class User extends Authenticatable implements MustVerifyEmail
         HasApiTokens,
         Notifiable,
         HasDynamicRelationships,
-        LogsActivity,
+        HasActivity,
         CausesActivity;
 
     /**
@@ -164,11 +164,10 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         $subject    = $activity->subject;
         $action     = ucfirst($eventName);
-        $properties = ['icon' => 'users'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "users/{$subject->id}/edit";
-        }
+        $properties = [
+            'link' => "users/{$subject->id}/edit",
+            'icon' => 'users'
+        ];
 
         $activity->description = "{$action} user account ({$subject->name})";
         $activity->properties  = $properties;

--- a/stubs/matrices/collection.stub
+++ b/stubs/matrices/collection.stub
@@ -5,13 +5,13 @@ namespace Fusion\Models\Collections;
 use Fusion\Models\Field;
 use Fusion\Models\Matrix;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class {class} extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
 	/**
      * The table associated with the model.
@@ -101,11 +101,10 @@ class {class} extends Model
         $matrix     = $entry->matrix;
         $action     = Str::ucfirst($eventName);
         $modelName  = Str::singular($matrix->name);
-        $properties = ['icon' => $matrix->icon];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "collections/{$matrix->slug}/{$entry->id}/edit";
-        }
+        $properties = [
+            'link' => "collections/{$matrix->slug}/{$entry->id}/edit",
+            'icon' => $matrix->icon
+        ];
 
         $activity->description = "{$action} {$modelName} ({$entry->name})";
         $activity->properties  = $properties;

--- a/stubs/matrices/form.stub
+++ b/stubs/matrices/form.stub
@@ -5,13 +5,13 @@ namespace Fusion\Models\Forms;
 use Fusion\Models\Form;
 use Fusion\Models\Field;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class {class} extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
 	/**
      * The table associated with the model.
@@ -99,11 +99,10 @@ class {class} extends Model
         $form       = $response->form;
         $action     = ucfirst($eventName);
         $modelName  = strtolower(Str::singular($form->name));
-        $properties = ['icon' => $form->icon];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "forms/{$form->slug}/responses/{$response->id}/edit";
-        }
+        $properties = [
+            'link' => "forms/{$form->slug}/responses/{$response->id}/edit",
+            'icon' => $form->icon
+        ];
 
         $activity->description = "{$action} {$modelName} form response ({$response->name})";
         $activity->properties  = $properties;

--- a/stubs/matrices/menu.stub
+++ b/stubs/matrices/menu.stub
@@ -6,14 +6,14 @@ use Fusion\Models\Menu;
 use Fusion\Models\Field;
 use Fusion\Concerns\HasOrder;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class {class} extends Model
 {
-    use HasOrder, LogsActivity;
+    use HasOrder, HasActivity;
 
 	/**
      * The table associated with the model.
@@ -86,11 +86,10 @@ class {class} extends Model
         $menu       = $node->menu;
         $action     = ucfirst($eventName);
         $modelName  = strtolower(Str::singular($menu->name));
-        $properties = ['icon' => 'anchor'];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "menus/{$menu->id}/nodes/{$node->id}/edit";
-        }
+        $properties = [
+            'link' => "menus/{$menu->id}/nodes/{$node->id}/edit",
+            'icon' => 'anchor'
+        ];
 
         $activity->description = "{$action} {$modelName} menu node ({$node->name})";
         $activity->properties  = $properties;

--- a/stubs/matrices/page.stub
+++ b/stubs/matrices/page.stub
@@ -5,13 +5,13 @@ namespace Fusion\Models\Pages;
 use Fusion\Models\Field;
 use Fusion\Models\Matrix;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class {class} extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
 	/**
      * The table associated with the model.

--- a/stubs/matrices/taxonomy.stub
+++ b/stubs/matrices/taxonomy.stub
@@ -5,13 +5,13 @@ namespace Fusion\Models\Taxonomies;
 use Fusion\Models\Field;
 use Fusion\Models\Taxonomy;
 use Illuminate\Support\Str;
+use Fusion\Concerns\HasActivity;
 use Fusion\Database\Eloquent\Model;
 use Spatie\Activitylog\Models\Activity;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 class {class} extends Model
 {
-    use LogsActivity;
+    use HasActivity;
 
 	/**
      * The table associated with the model.
@@ -92,11 +92,10 @@ class {class} extends Model
         $taxonomy   = $term->taxonomy;
         $action     = ucfirst($eventName);
         $modelName  = strtolower(Str::singular($taxonomy->name));
-        $properties = ['icon' => $taxonomy->icon];
-
-        if ($eventName !== 'deleted') {
-            $properties['link'] = "taxonomies/{$taxonomy->slug}/{$term->id}/edit";
-        }
+        $properties = [
+            'link' => "taxonomies/{$taxonomy->slug}/{$term->id}/edit",
+            'icon' => $taxonomy->icon
+        ];
 
         $activity->description = "{$action} {$modelName} term ({$term->name})";
         $activity->properties  = $properties;

--- a/tests/src/Feature/ActivityTest.php
+++ b/tests/src/Feature/ActivityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Fusion\Tests\Feature;
+
+use Fusion\Models\Matrix;
+use Fusion\Tests\TestCase;
+use Illuminate\Support\Collection;
+use Spatie\Activitylog\Models\Activity;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     * @group fusioncms
+     * @group activity
+     */
+    public function models_with_activity_logging_will_log_created_event()
+    {
+    	$attributes = factory(Matrix::class)->make()->toArray();
+
+    	$this
+    		->be($this->admin, 'api')
+    		->json('POST', '/api/matrices', $attributes);
+
+    	$matrix = Matrix::latest()->first();
+
+    	$this->assertDatabaseHas('activity_log', [
+    		'description'  => "Created matrix ({$attributes['name']})",
+    		'subject_id'   => $matrix->id,
+    		'subject_type' => 'Fusion\Models\Matrix',
+    	]);
+    }
+
+    /**
+     * @test
+     * @group fusioncms
+     * @group activity
+     */
+    public function models_with_activity_logging_will_log_updated_event()
+    {
+		$matrix = factory(Matrix::class)->create();
+
+		$attributes         = $matrix->toArray();
+		$attributes['name'] = 'New Name';
+		$attributes['slug'] = 'new-name';
+
+		$this
+			->be($this->admin, 'api')
+			->json('PATCH', '/api/matrices/' . $matrix->id, $attributes);
+
+		$this->assertDatabaseHas('activity_log', [
+			'description'  => "Updated matrix ({$attributes['name']})",
+			'subject_id'   => $attributes['id'],
+			'subject_type' => 'Fusion\Models\Matrix',
+		]);
+    }
+
+    /**
+     * @test
+     * @group fusioncms
+     * @group activity
+     */
+    public function activity_log_will_store_pertenant_info_for_the_dashboard()
+    {
+    	$this->actingAs($this->admin, 'api');
+
+    	$matrix   = factory(Matrix::class)->create();
+    	$activity = Activity::latest('id')->first();
+
+    	$this->assertDatabaseHas('activity_log', [
+    		'id'           => $activity->id,
+    		'log_name'     => 'default',
+    		'description'  => "Created matrix ({$matrix->name})",
+    		'subject_id'   => $matrix->id,
+    		'subject_type' => 'Fusion\Models\Matrix',
+    		'causer_id'    => $this->admin->id,
+    		'causer_type'  => 'Fusion\Models\User'
+    	]);
+
+    	$this->assertEquals($activity->properties['icon'], 'hashtag');
+    	$this->assertEquals($activity->properties['link'], "matrices/{$matrix->id}/edit");
+    }
+
+    /**
+     * @test
+     * @group fusioncms
+     * @group activity
+     */
+    public function hosting_model_can_ask_for_all_activities_recorded_by_it()
+    {
+    	$matrix = factory(Matrix::class)->create();
+
+    	$this->assertInstanceOf(Collection::class, $matrix->activities);
+    	$this->assertInstanceOf(Activity::class, $matrix->activities->first());
+    	$this->assertCount(1, $matrix->activities);
+    }
+
+    /**
+     * @test
+     * @group fusioncms
+     * @group activity
+     */
+    public function a_deleted_model_will_delete_its_own_logged_activities()
+    {
+    	$matrix = factory(Matrix::class)->create();
+    	$matrix->delete();
+
+    	$this->assertInstanceOf(Collection::class, $matrix->activities);
+    	$this->assertCount(0, $matrix->activities);
+
+    	$this->assertDatabaseMissing('activity_log', [
+			'subject_id'   => $matrix->id,
+			'subject_type' => 'Fusion\Models\Matrix',
+		]);
+    }
+}

--- a/tests/src/Feature/FieldsetTest.php
+++ b/tests/src/Feature/FieldsetTest.php
@@ -21,7 +21,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_attached_all_fields_should_generate_database_columns()
     {
@@ -38,7 +37,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_detached_all_fields_should_drop_database_columns()
     {
@@ -57,7 +55,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_replaced_database_columns_should_merge_if_compatible()
     {
@@ -101,7 +98,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_replaced_database_columns_should_drop_if_irrelevant()
     {
@@ -149,7 +145,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_field_is_added_a_database_column_should_be_generated_on_all_attached_tables()
     {
@@ -172,7 +167,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_field_is_removed_the_associated_database_column_should_be_removed_from_all_tables()
     {
@@ -196,7 +190,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_field_is_renamed_the_associated_database_column_should_also_be_renamed()
     {
@@ -228,7 +221,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_fields_fieldtype_is_changed_the_associated_database_columns_type_should_also_change()
     {
@@ -253,7 +245,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_field_is_retyped_the_associated_database_column_should_also_be_retyped()
     {
@@ -290,7 +281,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function when_a_field_is_renamed_and_new_field_created_in_its_name_database_should_have_both_columns()
     {
@@ -337,7 +327,6 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
-     * @group collection
      */
     public function each_fieldset_must_have_a_unique_handle()
     {

--- a/tests/src/Feature/FieldsetTest.php
+++ b/tests/src/Feature/FieldsetTest.php
@@ -21,6 +21,7 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
+     * @group collection
      */
     public function when_attached_all_fields_should_generate_database_columns()
     {
@@ -37,6 +38,7 @@ class FieldsetTest extends TestCase
      * @test
      * @group fusioncms
      * @group fieldset
+     * @group collection
      */
     public function when_detached_all_fields_should_drop_database_columns()
     {
@@ -51,7 +53,12 @@ class FieldsetTest extends TestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_replaced_database_columns_should_merge_if_compatible()
     {
         $redSection  = SectionFactory::times(1)->withoutFields()->create();
@@ -90,7 +97,12 @@ class FieldsetTest extends TestCase
         ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_replaced_database_columns_should_drop_if_irrelevant()
     {
         $redSection  = SectionFactory::times(1)->withoutFields()->create();
@@ -133,7 +145,12 @@ class FieldsetTest extends TestCase
         ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_field_is_added_a_database_column_should_be_generated_on_all_attached_tables()
     {
         $fieldset    = FieldsetFactory::create();
@@ -151,7 +168,12 @@ class FieldsetTest extends TestCase
         $this->assertDatabaseTableHasColumn($newsTable, $field->handle);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_field_is_removed_the_associated_database_column_should_be_removed_from_all_tables()
     {
         $fieldset = FieldsetFactory::create();
@@ -170,7 +192,12 @@ class FieldsetTest extends TestCase
         $this->assertDatabaseTableDoesNotHaveColumn($newsTable, $field->handle);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_field_is_renamed_the_associated_database_column_should_also_be_renamed()
     {
         $fieldset    = FieldsetFactory::create();
@@ -197,7 +224,12 @@ class FieldsetTest extends TestCase
         $this->assertDatabaseTableHasColumn($newsTable, $fieldInstance->handle);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_fields_fieldtype_is_changed_the_associated_database_columns_type_should_also_change()
     {
         $fieldset = FieldsetFactory::create();
@@ -217,7 +249,12 @@ class FieldsetTest extends TestCase
         $this->assertDatabaseTableColumnHasType($table, $field->handle, 'text');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_field_is_retyped_the_associated_database_column_should_also_be_retyped()
     {
         $section  = SectionFactory::times(1)->withoutFields()->create();
@@ -249,7 +286,12 @@ class FieldsetTest extends TestCase
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     * @group fusioncms
+     * @group fieldset
+     * @group collection
+     */
     public function when_a_field_is_renamed_and_new_field_created_in_its_name_database_should_have_both_columns()
     {
         // Create fieldset..
@@ -293,8 +335,9 @@ class FieldsetTest extends TestCase
 
     /**
      * @test
-     * @group feature
+     * @group fusioncms
      * @group fieldset
+     * @group collection
      */
     public function each_fieldset_must_have_a_unique_handle()
     {

--- a/tests/src/Feature/FileManager/DirectoryTest.php
+++ b/tests/src/Feature/FileManager/DirectoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\FileManager;
 
 use Fusion\Tests\TestCase;
 use Illuminate\Auth\AuthenticationException;

--- a/tests/src/Feature/FileManager/DirectoryTest.php
+++ b/tests/src/Feature/FileManager/DirectoryTest.php
@@ -89,16 +89,15 @@ class DirectoryTest extends TestCase
      * @group feature
      * @group directory
      */
-    public function activity_will_be_tracked_when_directory_is_deleted()
+    public function activities_will_be_cleaned_up_for_directory_when_it_is_deleted()
     {
         $this
             ->be($this->admin, 'api')
             ->json('DELETE', 'api/directories/' . $this->directoryA->id);
 
-        $this->assertDatabaseHas('activity_log', [
-            'description' => 'Deleted folder (Lorem)',
-            'causer_id'   => $this->admin->id,
-            'subject_id'  => $this->directoryA->id,
+        $this->assertDatabaseMissing('activity_log', [
+            'subject_id'   => $this->directoryA->id,
+            'subject_type' => 'Fusion\Models\Directory',
         ]);
     }
 

--- a/tests/src/Feature/FileManager/FileTest.php
+++ b/tests/src/Feature/FileManager/FileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\FileManager;
 
 use Fusion\Models\File;
 use Fusion\Tests\TestCase;

--- a/tests/src/Feature/FormTest.php
+++ b/tests/src/Feature/FormTest.php
@@ -468,18 +468,16 @@ class FormTest extends TestCase
      * @group form
      * @group activity
      */
-    public function a_deleted_form_should_be_logged_as_an_activity()
+    public function activities_will_be_cleaned_up_for_form_when_it_is_deleted()
     {
         $this->actingAs($this->admin, 'api');
         $form = FormFactory::create();
 
         $this->json('DELETE', '/api/forms/' . $form->id);
 
-        $this->assertDatabaseHas('activity_log', [
-            'description' => "Deleted form ({$form->name})",
-            'subject_id'  => $form->id,
-            'causer_type' => 'Fusion\Models\User',
-            'causer_id'   => $this->admin->id,
+        $this->assertDatabaseMissing('activity_log', [
+            'subject_id'   => $form->id,
+            'subject_type' => 'Fusion\Models\Forms',
         ]);
     }
 }

--- a/tests/src/Feature/Matrix/CollectionTest.php
+++ b/tests/src/Feature/Matrix/CollectionTest.php
@@ -23,7 +23,7 @@ class CollectionTest extends TestCase
         $this->fieldExcerpt = \Facades\FieldFactory::withName('Excerpt')->withSection($this->section)->create();
         $this->fieldContent = \Facades\FieldFactory::withName('Content')->withType('textarea')->withSection($this->section)->create();
         $this->fieldset     = \Facades\FieldsetFactory::withName('General')->withSections(collect([$this->section]))->create();
-        $this->matrix       = \Facades\MatrixFactory::withName('Posts')->asCollection()->withFieldset($this->fieldset)->withRoute('posts/{slug}')->withTemplate('index')->create();
+        $this->matrix       = \Facades\MatrixFactory::withName('Collectibles')->asCollection()->withFieldset($this->fieldset)->withRoute('collectibles/{slug}')->withTemplate('index')->create();
         $this->model        = (new \Fusion\Services\Builders\Collection($this->matrix->handle))->make();
     }
 
@@ -46,10 +46,10 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin, 'api')
-            ->json('POST', '/api/collections/posts', $attributes)
+            ->json('POST', '/api/collections/collectibles', $attributes)
             ->assertStatus(201);
 
-        $this->assertDatabaseHas('mx_posts', $attributes);
+        $this->assertDatabaseHas('mx_collectibles', $attributes);
     }
 
     /**
@@ -63,7 +63,7 @@ class CollectionTest extends TestCase
     {
         $this->expectException(AuthenticationException::class);
 
-        $this->json('POST', '/api/collections/posts', []);
+        $this->json('POST', '/api/collections/collectibles', []);
     }
 
     /**
@@ -79,7 +79,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->user, 'api')
-            ->json('POST', '/api/collections/posts', []);
+            ->json('POST', '/api/collections/collectibles', []);
     }
 
     /**
@@ -102,10 +102,10 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin, 'api')
-            ->json('PATCH', '/api/collections/posts/' . $entry->id, $attributes)
+            ->json('PATCH', '/api/collections/collectibles/' . $entry->id, $attributes)
             ->assertStatus(200);
 
-        $this->assertDatabaseHas('mx_posts', $attributes);
+        $this->assertDatabaseHas('mx_collectibles', $attributes);
     }
 
     /**
@@ -121,9 +121,9 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin, 'api')
-            ->json('DELETE', '/api/collections/posts/' . $entry->id);
+            ->json('DELETE', '/api/collections/collectibles/' . $entry->id);
 
-        $this->assertDatabaseMissing('mx_posts', [ 'id' => $entry->id ]);
+        $this->assertDatabaseMissing('mx_collectibles', [ 'id' => $entry->id ]);
     }
 
     /**
@@ -139,7 +139,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin, 'api')
-            ->json('POST', '/api/collections/posts', $attributes)
+            ->json('POST', '/api/collections/collectibles', $attributes)
             ->assertStatus(422)
             ->assertJsonValidationErrors(['slug']);
     }
@@ -157,7 +157,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->user)
-            ->get('/posts/' . $entry->slug)
+            ->get('/collectibles/' . $entry->slug)
             ->assertStatus(200);
     }
 
@@ -176,7 +176,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->user)
-            ->get('/posts/' . $entry->slug);
+            ->get('/collectibles/' . $entry->slug);
     }
 
     /**
@@ -194,7 +194,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin)
-            ->get('/posts/' . $entry->slug);
+            ->get('/collectibles/' . $entry->slug);
     }
 
     /**
@@ -210,7 +210,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin)
-            ->get('/posts/' . $entry->slug . '?preview=true')
+            ->get('/collectibles/' . $entry->slug . '?preview=true')
             ->assertStatus(200);
     }
 
@@ -229,7 +229,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->user)
-            ->get('/posts/' . $entry->slug . '?preview=true');
+            ->get('/collectibles/' . $entry->slug . '?preview=true');
     }
 
     //
@@ -255,7 +255,7 @@ class CollectionTest extends TestCase
 
         $this
             ->be($this->admin, 'api')
-            ->json('POST', '/api/collections/posts', $attributes);
+            ->json('POST', '/api/collections/collectibles', $attributes);
 
         $entry = \DB::table($this->model->getTable())->first();
 

--- a/tests/src/Feature/Matrix/CollectionTest.php
+++ b/tests/src/Feature/Matrix/CollectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Matrix;
 
 use Fusion\Tests\TestCase;
 use Illuminate\Auth\AuthenticationException;

--- a/tests/src/Feature/Matrix/MatrixTest.php
+++ b/tests/src/Feature/Matrix/MatrixTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Matrix;
 
 use Fusion\Models\Matrix;
 use Facades\MatrixFactory;

--- a/tests/src/Feature/Matrix/PageTest.php
+++ b/tests/src/Feature/Matrix/PageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Matrix;
 
 use Fusion\Tests\TestCase;
 use Illuminate\Auth\AuthenticationException;

--- a/tests/src/Feature/Menu/MenuNodeTest.php
+++ b/tests/src/Feature/Menu/MenuNodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Menu;
 
 use Fusion\Tests\TestCase;
 use Illuminate\Support\Str;

--- a/tests/src/Feature/Menu/MenuTest.php
+++ b/tests/src/Feature/Menu/MenuTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Menu;
 
 use Fusion\Models\Menu;
 use Facades\MenuFactory;

--- a/tests/src/Feature/Taxonomy/TaxonomyTest.php
+++ b/tests/src/Feature/Taxonomy/TaxonomyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Taxonomy;
 
 use Fusion\Tests\TestCase;
 use Fusion\Models\Taxonomy;

--- a/tests/src/Feature/Taxonomy/TermTest.php
+++ b/tests/src/Feature/Taxonomy/TermTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Taxonomy;
 
 use Fusion\Tests\TestCase;
 use Illuminate\Support\Str;

--- a/tests/src/Feature/Users/RoleTest.php
+++ b/tests/src/Feature/Users/RoleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Users;
 
 use Fusion\Models\Role;
 use Fusion\Tests\TestCase;

--- a/tests/src/Feature/Users/UserTest.php
+++ b/tests/src/Feature/Users/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fusion\Tests\Feature;
+namespace Fusion\Tests\Feature\Users;
 
 use Fusion\Models\User;
 use Fusion\Tests\TestCase;


### PR DESCRIPTION
### What does this implement or fix?
- Adds `HasActivity` decorator trait for `LogsActivity` in order to clean up activities created by deleted model.
- Moved some test files around for re-organization purposes.

### Does this close any currently open issues?
- [fusioncms/fusioncms#493](https://github.com/fusioncms/fusioncms/issues/493)

### Screenshots
N/A

- [x] All javascript/scss resources are compiled for production