### PR TITLE
Installer patch

### DIFF
--- a/src/Concerns/CleansDirectories.php
+++ b/src/Concerns/CleansDirectories.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Fusion\Concerns;
+
+use Symfony\Component\Finder\Finder;
+use Illuminate\Support\Facades\File;
+
+trait CleansDirectories
+{
+    /**
+     * Remove all files and folders, ignoring `dot` files.
+     *
+     * @param  string  $directory
+     * @return void
+     */
+    protected function cleanDirectory($directory)
+    {
+        if (File::isDirectory($directory)) {
+            $files = Finder::create()->in($directory);
+            $paths = [];
+
+            foreach ($files as $file) {
+                $paths[] = $file->getPathname();
+            }
+
+            File::delete($paths);
+        }
+    }
+}

--- a/src/Console/Actions/SyncModules.php
+++ b/src/Console/Actions/SyncModules.php
@@ -2,12 +2,14 @@
 
 namespace Fusion\Console\Actions;
 
-use Symfony\Component\Finder\Finder;
 use Illuminate\Support\Facades\File;
+use Fusion\Concerns\CleansDirectories;
 use Caffeinated\Modules\Facades\Module;
 
 class SyncModules
 {
+    use CleansDirectories;
+
     /**
      * Execute the command.
      *
@@ -35,28 +37,6 @@ class SyncModules
                 );
             }
         });
-    }
-
-    /**
-     * Empty the specified directory of all files and folders
-     *   (but keeping the `.gitignore` file).
-     *
-     * @return void
-     */
-    protected function cleanDirectory($directory)
-    {
-        if (! File::exists($directory)) {
-            File::makeDirectory($directory);
-        }
-
-        $files = Finder::create()->in($directory);
-        $paths = [];
-
-        foreach ($files as $file) {
-            $paths[] = $file->getPathname();
-        }
-
-        File::delete($paths);
     }
 
     /**

--- a/src/Console/SyncCommand.php
+++ b/src/Console/SyncCommand.php
@@ -34,8 +34,6 @@ class SyncCommand extends Command
                 dispatch(new \Fusion\Console\Actions\SyncModules);
                 dispatch(new \Fusion\Console\Actions\SyncExtensions);
                 dispatch(new \Fusion\Console\Actions\SyncSettings);
-
-                \Fusion\Models\Mailable::registerNewMailables();
             });
         } catch (Exception $exception) {
             Log::error($exception->getMessage(), (array) $exception->getTrace()[0]);

--- a/src/Console/Uninstaller/DeleteDirectories.php
+++ b/src/Console/Uninstaller/DeleteDirectories.php
@@ -2,10 +2,12 @@
 
 namespace Fusion\Console\Uninstaller;
 
-use Illuminate\Support\Facades\File;
+use Fusion\Concerns\CleansDirectories;
 
 class DeleteDirectories
 {
+    use CleansDirectories;
+    
     /**
      * Execute the command.
      *
@@ -25,13 +27,8 @@ class DeleteDirectories
      */
     private function deleteModuleDirectories()
     {
-        if (File::exists(base_path('modules'))) {
-            File::deleteDirectory(base_path('modules'));
-        }
-
-        if (File::exists(public_path('modules'))) {
-            File::deleteDirectory(public_path('modules'));
-        }
+        $this->cleanDirectory(base_path('modules'));
+        $this->cleanDirectory(public_path('modules'));
     }
 
     /**
@@ -42,12 +39,7 @@ class DeleteDirectories
      */
     private function deleteThemeDirectories()
     {
-        if (File::exists(base_path('themes'))) {
-            File::deleteDirectory(base_path('themes'));
-        }
-
-        if (File::exists(public_path('themes'))) {
-            File::deleteDirectory(public_path('themes'));
-        }
+        $this->cleanDirectory(base_path('themes'));
+        $this->cleanDirectory(public_path('themes'));
     }
 }

--- a/src/Providers/FusionServiceProvider.php
+++ b/src/Providers/FusionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Fusion\Providers;
 
+use Fusion\Models\Mailable;
 use Laravel\Passport\Passport;
 use Caffeinated\Themes\Facades\Theme;
 use Illuminate\Support\Facades\Route;
@@ -28,6 +29,7 @@ class FusionServiceProvider extends ServiceProvider
         if (app_installed()) {
             $this->registerBonsai();
             $this->registerTheme();
+            $this->registerMailables();
         }
     }
 
@@ -131,10 +133,21 @@ class FusionServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerMigrations() {
+    private function registerMigrations()
+    {
         if ($this->app->runningInConsole()) {
             $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
         }
+    }
+
+    /**
+     * Register Mailables templates.
+     * 
+     * @return void
+     */
+    private function registerMailables()
+    {
+        Mailable::registerNewMailables();
     }
 
     /**


### PR DESCRIPTION
### What does this implement or fix?
This update patches the issue below causing Installer to error out on registering Mailables.

- Mailables now register themselves within `FusionServiceProvider`.
- Centralized `cleanDirectory` method, and updated installer for usage (this cleans folder instead of deleting/creating).

### Does this close any currently open issues?
- [fusioncms/fusioncms#507](https://github.com/fusioncms/fusioncms/issues/507)

- [x] All javascript/scss resources are compiled for production