### PR TITLE
Handling non-GD compatible images

### DIFF
--- a/src/Http/Controllers/Web/FileController.php
+++ b/src/Http/Controllers/Web/FileController.php
@@ -24,7 +24,7 @@ class FileController extends Controller
             return redirect()->to('/file/' . $uuid . '/' . $file->name . '?' . http_build_query($params));
         }
 
-        if (Str::startsWith($file->mimetype, 'image') and $file->mimetype !== 'image/gif') {
+        if (in_array($file->mimetype, ['image/jpeg', 'image/gif', 'image/png'])) {
             return $this->imageResponse($file->location, $params);
         }
 
@@ -32,7 +32,13 @@ class FileController extends Controller
             return $this->videoResponse($file->location, $file->mimetype);
         }
 
-        return Storage::disk('public')->response($file->location);
+        return Storage::disk('public')->response(
+            $file->location,
+            $file->name,
+            [
+                'Content-Type' => $file->mimetype
+            ]
+        );
     }
 
     protected function imageResponse($path, $params)


### PR DESCRIPTION
### What does this implement or fix?
This update resolves broken images appearing in the File Manager. These images were broken cause they failed to resolve through Glide's image response because of incompatibility (aka not a jpeg, gif, or png)

### Does this close any currently open issues?
- [fusioncms/fusioncms#504](https://github.com/fusioncms/fusioncms/issues/504)

### Screenshots
<img width="986" alt="Screen Shot 2020-05-15 at 4 01 33 PM" src="https://user-images.githubusercontent.com/8143970/82103231-1c8ecb80-96c7-11ea-90e1-26dbc156be97.png">
