### PR TITLE
Add theme template support

### DIFF
--- a/src/Console/MakeThemeCommand.php
+++ b/src/Console/MakeThemeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Fusion\Console;
 
+use Fusion\Facades\Theme;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -33,6 +34,10 @@ class MakeThemeCommand extends Command
         $template  = $this->getTemplate();
         $manifest  = $this->getManifest();
 
+        if (! File::isDirectory($template)) {
+            return $this->error("No template found for '{$template}'");
+        }
+
         if (File::isDirectory(theme_path($namespace))) {
             return $this->error('Theme already exists!');
         }
@@ -59,11 +64,11 @@ class MakeThemeCommand extends Command
     {
         $template = $this->option('template', null);
 
-        // if (is_null($template)) {
+        if (is_null($template)) {
             return fusion_path('stubs/theme');
-        // }
+        }
 
-        // Otherwise, fetch the template theme and return its path
+        return theme_path("{$template}/template");
     }
 
     /**

--- a/src/Console/MakeThemeCommand.php
+++ b/src/Console/MakeThemeCommand.php
@@ -35,7 +35,7 @@ class MakeThemeCommand extends Command
         $manifest  = $this->getManifest();
 
         if (! File::isDirectory($template)) {
-            return $this->error("No template found for '{$template}'");
+            return $this->error("No template found at '{$template}'");
         }
 
         if (File::isDirectory(theme_path($namespace))) {
@@ -68,7 +68,7 @@ class MakeThemeCommand extends Command
             return fusion_path('stubs/theme');
         }
 
-        return theme_path("{$template}/template");
+        return base_path("templates/{$template}");
     }
 
     /**


### PR DESCRIPTION
### What does this implement or fix?
- Adds in the ability to pass through a template when using `make:theme`

```
php artisan make:theme Foobar --template=oxygen
```

The `template` option accepts the name of a folder with the `templates` directory at the root of the project. The contents of the specified directory will be used as the scaffold for the new theme being generated.

An example template has been created for reference: https://github.com/fusioncms/example-template

There are a set of placeholder values available that the CMS will swap out with based on the values from the command:

- `{{name}}`
- `{{namespace}}`
- `{{description}}`
- `{{author}}`
- `{{version}}`

See here for an example: https://github.com/fusioncms/example-template/blob/master/theme.json

The `{{namespace}}` placeholder will also be important for any PHP namespaces included within your template. For example:

```php
<?php

namespace Themes\{{namespace}}\Providers;

use Illuminate\Support\ServiceProvider;

class ThemeServiceProvider extends ServiceProvider
{
    //
}
```

### Does this close any currently open issues?
- fusioncms/fusioncms#530

- [x] All javascript/scss resources are compiled for production