### PR TITLE
Config default updates

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1')),
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', parse_url(url(''), PHP_URL_HOST))),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/Installer/CreateEnvironmentConfig.php
+++ b/src/Console/Installer/CreateEnvironmentConfig.php
@@ -32,10 +32,6 @@ class CreateEnvironmentConfig
             'DB_DATABASE' => $container['db_name'],
             'DB_USERNAME' => $container['db_user'],
             'DB_PASSWORD' => $container['db_pass'],
-
-            // for sanctum
-            'SESSION_DOMAIN' => '.'.parse_url($container['app_url'], PHP_URL_HOST),
-            'SANCTUM_STATEFUL_DOMAINS' => parse_url($container['app_url'], PHP_URL_HOST),
         ];
     }
 


### PR DESCRIPTION
### What does this implement or fix?
Made updates to our default configurations to `SESSION_DRIVER` and `SANCTUM_STATEFUL_DOMAINS`. Still leaving in the opportunity to override them.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#573](https://github.com/fusioncms/fusioncms/issues/573)