### PR TITLE
Simple redirect if FusionCMS not installed

### DIFF
--- a/src/Http/Controllers/Web/RouterController.php
+++ b/src/Http/Controllers/Web/RouterController.php
@@ -18,6 +18,10 @@ class RouterController extends Controller
      */
     public function handle(Request $request)
     {
+        if (! app_installed()) {
+            return redirect('/install');
+        }
+
         $routers = [
             HomepageRouter::class,
             EntryRouter::class,


### PR DESCRIPTION
### What does this implement or fix?
Simply redirecting to `/install` page if FusionCMS is not installed.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#572](https://github.com/fusioncms/fusioncms/issues/572)
