### PR TITLE
Directory permission check

### DIFF
--- a/src/Console/Actions/CheckServerRequirements.php
+++ b/src/Console/Actions/CheckServerRequirements.php
@@ -72,7 +72,7 @@ class CheckServerRequirements
                 $folder,
                 $actual,
                 $perm,
-                ($actual == $perm) ? '√' : 'x'
+                ($actual >= $perm) ? '√' : 'x'
             ];
         })->toArray();
     }
@@ -108,7 +108,7 @@ class CheckServerRequirements
     public static function verifyFolderPermissions()
     {
        return collect(config('installer.permissions'))->every(function($perm, $folder) {
-            return substr(sprintf('%o', fileperms(base_path($folder))), -3) == $perm;
+            return substr(sprintf('%o', fileperms(base_path($folder))), -3) >= $perm;
         });
     }
 }


### PR DESCRIPTION
### What does this implement or fix?
Frees up directory permission check with installer.
Now checking for a minimal of `755`.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#580](https://github.com/fusioncms/fusioncms/issues/580)

### Screenshots
<img width="350" alt="Screen Shot 2020-06-29 at 10 21 08 AM" src="https://user-images.githubusercontent.com/8143970/86036141-49d2d700-b9f2-11ea-8946-494b700df5cc.png">
<img width="354" alt="Screen Shot 2020-06-29 at 10 21 02 AM" src="https://user-images.githubusercontent.com/8143970/86036148-4ccdc780-b9f2-11ea-99c5-ca3c985df759.png">