### PR TITLE
Delete old symlink if present

### DIFF
--- a/src/Services/Theme.php
+++ b/src/Services/Theme.php
@@ -87,6 +87,10 @@ class Theme extends Collection
             $folder = $this->active()->get('namespace');
 
             if (File::exists(theme_path("{$folder}/public"))) {
+                // Delete existing symlink if present
+                File::delete(public_path('theme'));
+
+                // Create new theme symlink
                 File::link(
                     theme_path("{$folder}/public"),
                     public_path('theme')


### PR DESCRIPTION
### What does this implement or fix?
- When activating a new theme, the old symlink is removed first

### Does this close any currently open issues?
- resolves fusioncms/fusioncms#584

- [x] All javascript/scss resources are compiled for production