### PR TITLE
Automatically merge theme manifest changes in

### DIFF
--- a/helpers/themes.php
+++ b/helpers/themes.php
@@ -71,18 +71,6 @@ if (! function_exists('theme_option')) {
         } else {
             $optionsFilePath = storage_path('app/themes/'.$theme->get('namespace').'.json');
 
-            if (! File::exists($optionsFilePath)) {
-                $defaults = collect($theme->get('options'))->mapWithKeys(function($section, $handle) {
-                    $options = collect($section['fields'])->mapWithKeys(function($option, $field) {
-                        return [$field => $option['default'] ?? null];
-                    });
-
-                    return [$handle => $options];
-                });
-
-                File::put($optionsFilePath, json_encode($defaults, JSON_PRETTY_PRINT));
-            }
-
             $options = collect(json_decode(File::get($optionsFilePath), true));
             $values  = $values->merge($options);
         }

--- a/src/Providers/ThemeServiceProvider.php
+++ b/src/Providers/ThemeServiceProvider.php
@@ -57,6 +57,12 @@ class ThemeServiceProvider extends ServiceProvider
         return ['theme'];
     }
 
+    /**
+     * Generate the themes options file.
+     *
+     * @param  \Fusion\Services\Manifest  $manifest
+     * @return void
+     */
     protected function generateOptions($manifest)
     {
         $optionsPath = storage_path('app/themes/'.$manifest->get('namespace').'.json');

--- a/src/Providers/ThemeServiceProvider.php
+++ b/src/Providers/ThemeServiceProvider.php
@@ -4,6 +4,7 @@ namespace Fusion\Providers;
 
 use Fusion\Services\Theme;
 use Fusion\Services\Manifest;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 
 class ThemeServiceProvider extends ServiceProvider
@@ -35,6 +36,9 @@ class ThemeServiceProvider extends ServiceProvider
                 foreach ($themes as $theme) {
                     $manifest              = new Manifest($theme.'/theme.json');
                     $namespace             = $manifest->get('namespace');
+
+                    $this->generateOptions($manifest);
+
                     $manifests[$namespace] = collect($manifest->all());
                 }
             }
@@ -51,5 +55,43 @@ class ThemeServiceProvider extends ServiceProvider
     public function provides()
     {
         return ['theme'];
+    }
+
+    protected function generateOptions($manifest)
+    {
+        $optionsPath = storage_path('app/themes/'.$manifest->get('namespace').'.json');
+
+        if (! File::exists($optionsPath)) {
+            $defaults = $this->getDefaultOptions($manifest);
+
+            File::put($optionsPath, json_encode($defaults, JSON_PRETTY_PRINT));
+        }
+
+        $optionsModified  = File::lastModified($optionsPath);
+        $manifestModified = File::lastModified($manifest->getPath());
+
+        if ($manifestModified > $optionsModified) {
+            $defaults = $this->getDefaultOptions($manifest);
+            $options  = collect(json_decode(File::get($optionsPath), true));
+
+            $merged = $defaults->map(function($items, $section) use ($options) {
+                return $items->merge($options->get($section));
+            });
+
+            File::put($optionsPath, json_encode($merged, JSON_PRETTY_PRINT));
+        }
+
+        // dd('done', $manifest->getPath(), $manifestModified, $optionsModified, $manifestModified > $optionsModified);
+    }
+
+    protected function getDefaultOptions($manifest)
+    {
+        return collect($manifest->get('options'))->mapWithKeys(function($section, $handle) {
+            $options = collect($section['fields'])->mapWithKeys(function($option, $field) {
+                return [$field => $option['default'] ?? null];
+            });
+
+            return [$handle => $options];
+        });
     }
 }

--- a/src/Providers/ThemeServiceProvider.php
+++ b/src/Providers/ThemeServiceProvider.php
@@ -80,10 +80,14 @@ class ThemeServiceProvider extends ServiceProvider
 
             File::put($optionsPath, json_encode($merged, JSON_PRETTY_PRINT));
         }
-
-        // dd('done', $manifest->getPath(), $manifestModified, $optionsModified, $manifestModified > $optionsModified);
     }
 
+    /**
+     * Get the default option values from the manifest file.
+     *
+     * @param  \Fusion\Services\Manifest  $manifest
+     * @return \Illuminate\Support\Collection
+     */
     protected function getDefaultOptions($manifest)
     {
         return collect($manifest->get('options'))->mapWithKeys(function($section, $handle) {


### PR DESCRIPTION
### What does this implement or fix?
Moved the responsibility of creating the theme option cache file out from the `theme_option` helper function to the service provider. This not only cleans up the responsibilities, but allows us to catch when a theme manifest has been updated, prompting that we should check for changes and merge options as necessary.

No longer need to visit the frontend before jumping to the customize page :v:

### Does this close any currently open issues?
- resolves fusioncms/fusioncms#576

- [x] All javascript/scss resources are compiled for production