### PR TITLE
Maintain current url when customizing theme

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -68,7 +68,6 @@ Route::group(['prefix' => config('fusion.path')], function () {
 
 Route::group(['middleware' => ['can:themes.update']], function() {
     Route::post('/customize', 'CustomizeController@show');
-    Route::post('/{any?}/customize', 'CustomizeController@show')->where('any', '.*');
 });
 
 Route::post('form/{form}', 'ResponseController@store');

--- a/src/Http/Controllers/Web/CustomizeController.php
+++ b/src/Http/Controllers/Web/CustomizeController.php
@@ -4,6 +4,7 @@ namespace Fusion\Http\Controllers\Web;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Session;
 use Fusion\Http\Controllers\Controller;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -12,11 +13,20 @@ class CustomizeController extends Controller
     public function show(Request $request)
     {
         $segments = $request->segments();
-
         array_pop($segments);
+        $route = '/'.implode('/', $segments);
 
-        $route   = '/'.implode('/', $segments);
-        $secondaryRequest = SymfonyRequest::create($route);
+        $previous = (object) parse_url(session()->get('_previous.url'));
+
+        if (
+            (optional($previous)->path != '/admin/customize') and
+            (optional($previous)->path != $request->path()) and
+            (optional($previous)->path)
+        ) {
+            $route = $previous->path;
+        }
+
+        $secondaryRequest = Request::create($route);
 
         $secondaryRequest->headers->set('X-FusionCMS-Customize', true);
         $secondaryRequest->attributes->set('customize', $request->all());

--- a/src/Http/Controllers/Web/CustomizeController.php
+++ b/src/Http/Controllers/Web/CustomizeController.php
@@ -4,9 +4,7 @@ namespace Fusion\Http\Controllers\Web;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Facades\Session;
 use Fusion\Http\Controllers\Controller;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class CustomizeController extends Controller
 {

--- a/src/Providers/FusionServiceProvider.php
+++ b/src/Providers/FusionServiceProvider.php
@@ -50,10 +50,7 @@ class FusionServiceProvider extends ServiceProvider
 
         $this->registerFusion();
         $this->registerConfig();
-
-        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
-        $kernel->pushMiddleware(\Fusion\Http\Middleware\DecodeFormData::class);
-        $kernel->prependMiddlewareToGroup('api', \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class);
+        $this->registerMiddleware();
 
         $this->commands([
             \Fusion\Console\Addons\RollbackCommand::class,
@@ -73,6 +70,20 @@ class FusionServiceProvider extends ServiceProvider
             \Fusion\Console\FlushCommand::class,
             \Fusion\Console\SyncCommand::class,
         ]);
+    }
+
+    /**
+     * Register middleware.
+     *
+     * @return void
+     */
+    protected function registerMiddleware()
+    {
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
+
+        $kernel->prependMiddlewareToGroup('api', \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class);
+
+        $kernel->pushMiddleware(\Fusion\Http\Middleware\DecodeFormData::class);
     }
 
     /**


### PR DESCRIPTION
### What does this implement or fix?
- Maintains the current URL when customzing a theme. This allows users to navigate around the website while customizing the theme to see how the customizations look/feel on various pages :+1:

### Does this close any currently open issues?
- resolves fusioncms/fusioncms#579

- [x] All javascript/scss resources are compiled for production