### PR TITLE
api.rate_limit setting

### DIFF
--- a/settings/api.php
+++ b/settings/api.php
@@ -16,6 +16,19 @@ return [
                 'default'     => 'disabled',
                 'required'    => true,
             ],
+            [
+                'name'        => 'Rate Limit',
+                'handle'      => 'rate_limit',
+                'description' => 'Set default request limit for users within a minute.',
+                'type'        => 'number',
+                'options'     => [
+                    'min'  => 20,
+                    'max'  => 120,
+                    'step' => 10,
+                ],
+                'default'     => '60',
+                'required'    => false,
+            ]
         ],
     ],
 ];

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -43,9 +43,9 @@ trait HasRoles
      */
     public function getRateLimitAttribute()
     {
-        // if ($this->isOwner()) {
-        //     return 1000;
-        // }
+        if ($this->isOwner()) {
+            return 1000;
+        }
 
         return setting('api.rate_limit', 60);
     }

--- a/src/Concerns/HasRoles.php
+++ b/src/Concerns/HasRoles.php
@@ -35,4 +35,18 @@ trait HasRoles
     {
         return $this->hasRole('owner');
     }
+
+    /**
+     * Returns throttle rate limit for authenticated user.
+     * 
+     * @return integer
+     */
+    public function getRateLimitAttribute()
+    {
+        // if ($this->isOwner()) {
+        //     return 1000;
+        // }
+
+        return setting('api.rate_limit', 60);
+    }
 }


### PR DESCRIPTION
### What does this implement or fix?
This update aims to curb the unexpected **429-Too Many Requests** response when using the control panel at a faster than casual rate.

- Adds new `api.rate_limit` default setting for authenticated users.
- Owner will get `1000` requests per minute, which should be plenty.

#### Possible followups:
- Override default `api.rate limit` setting per Role.

#### Important:
Make sure you update your `App\Http\Kernel` file for this update to be recognized.
For more info, [click here](https://laravel.com/docs/7.x/routing#rate-limiting).

**Yours may look like:**
```php
'api' => [
    'throttle:60,1',
    \Illuminate\Routing\Middleware\SubstituteBindings::class,
],
```

**Updated version:**
```php
'api' => [
    'throttle:60|rate_limit,1',
    \Illuminate\Routing\Middleware\SubstituteBindings::class,
],
```

### Screenshots
![fusioncms-v6 test_admin_settings_api(1920 x 1080)](https://user-images.githubusercontent.com/8143970/87729564-8a647b80-c77a-11ea-8c75-86f99893b443.png)


### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#594](https://github.com/fusioncms/fusioncms/issues/594)