### PR TITLE
Fixed HomepageRouter throwing "Trying to get property 'data' of non-object" exception

### DIFF
--- a/src/Services/Routers/HomepageRouter.php
+++ b/src/Services/Routers/HomepageRouter.php
@@ -3,6 +3,7 @@
 namespace Fusion\Services\Routers;
 
 use Fusion\Models\Matrix;
+use Fusion\Services\Builders\Single;
 use Illuminate\Http\Request;
 
 class HomepageRouter extends Router
@@ -10,13 +11,16 @@ class HomepageRouter extends Router
     public function handle(Request $request)
     {
         if ($this->matchRoute('/', $request)) {
-            $single = Matrix::where('route', '/')->first();
+            $matrix = Matrix::where('route', '/')->first();
 
-            if ($single) {
-                $data = fusion()->get('singles/'.$single->id);
-                $data = $this->bindRouteData('/', $request, (array) $data->data);
+            if ($matrix) {
+                $model = (new Single($matrix->handle))->make();
+                $page  = $model->firstOrFail();
 
-                return view($single->template, $data);
+                return view(trim($matrix->template) == '' ? 'index' : $matrix->template, [
+                    'matrix' => $matrix,
+                    'page'   => $page,
+                ]);
             } else {
                 return view('index');
             }


### PR DESCRIPTION

### What does this implement or fix?
Fixed HomepageRouter throwing "Trying to get property 'data' of non-object" exception.

### Does this close any currently open issues?
- fusioncms/fusioncms#636