### PR TITLE
Mailables sync

### DIFF
--- a/src/Console/SyncCommand.php
+++ b/src/Console/SyncCommand.php
@@ -34,6 +34,8 @@ class SyncCommand extends Command
                 dispatch(new \Fusion\Console\Actions\SyncAddons());
                 dispatch(new \Fusion\Console\Actions\SyncSettings());
                 dispatch(new \Fusion\Console\Actions\SyncPermissions());
+
+                \Fusion\Models\Mailable::registerNewMailables();                
             });
         } catch (Exception $exception) {
             Log::error($exception->getMessage(), (array) $exception->getTrace()[0]);

--- a/src/Http/Controllers/DataTable/MailableController.php
+++ b/src/Http/Controllers/DataTable/MailableController.php
@@ -9,8 +9,6 @@ class MailableController extends DataTableController
 {
     public function builder()
     {
-        Mailable::registerNewMailables();
-
         return Mailable::active();
     }
 

--- a/tests/src/Concerns/InstallsFusion.php
+++ b/tests/src/Concerns/InstallsFusion.php
@@ -48,8 +48,6 @@ trait InstallsFusion
 
         Artisan::call('fusion:flush');
         Artisan::call('fusion:sync');
-
-        Mailable::registerNewMailables();
     }
 
     /**


### PR DESCRIPTION
### What does this implement or fix?
Moved `Mailables:: registerNewMailables()` to `fusion:sync` so default mailables are loaded before anyone uses the control panel.

### Does this close any currently open issues?
- [fusioncms/fusioncms#666](https://github.com/fusioncms/fusioncms/issues/666)