### PR TITLE
Settings cache busting

### DIFF
--- a/src/Http/Controllers/API/SettingController.php
+++ b/src/Http/Controllers/API/SettingController.php
@@ -51,7 +51,7 @@ class SettingController extends Controller
             return $relationships->contains('handle', $handle);
         })->toArray();
 
-        $setting->settings()->update($validated);
+        $setting->settings->update($validated);
 
         // Persist relationships...
         foreach ($relationships as $relationship) {


### PR DESCRIPTION
### What does this implement or fix?
This update makes a minor update to allow for cache busting when settings are saved.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#665](https://github.com/fusioncms/fusioncms/issues/665)
