### PR TITLE
Fixed web installer bug where cannot proceed to install at database page

### DIFF
--- a/resources/views/installer/database.blade.php
+++ b/resources/views/installer/database.blade.php
@@ -18,19 +18,19 @@
 		/>
 
 		<x-installer.input
-			name="db_name"
+			name="db_database"
 			label="Database Name"
 			value="{{ $data['db_database'] ?? 'fusioncms' }}"
 		/>
 
 		<x-installer.input
-			name="db_user"
+			name="db_username"
 			label="Username"
 			value="{{ $data['db_username'] ?? 'homestead' }}"
 		/>
 
 		<x-installer.input
-			name="db_pass"
+			name="db_password"
 			type="password"
 			label="Password"
 			value="{{ $data['db_password'] ?? 'secret' }}"


### PR DESCRIPTION
### What does this implement or fix?
When click on the next button on web installer database setting page, the installer cannot proceed to install as the field db_database, db_username and db_password was not set even the user entered the value in the textbox, as the textbox name was not matched with the name used in the contoller/validator.

name in input in view: db_name, db_user, db_pass
correct name: db_database, db_username, db_password

### Does this close any currently open issues?
-