### PR TITLE
Backup patches

### DIFF
--- a/src/Jobs/Backups/BackupRun.php
+++ b/src/Jobs/Backups/BackupRun.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Throwable;
 
 class BackupRun implements ShouldQueue
 {
@@ -83,11 +84,11 @@ class BackupRun implements ShouldQueue
     /**
      * The job failed to process.
      *
-     * @param Exception $exception
+     * @param \Throwable $exception
      *
      * @return void
      */
-    public function failed(Exception $exception)
+    public function failed(Throwable $exception)
     {
         Log::error('There was an error trying to backup FusionCMS: '.$exception->getMessage(), (array) $exception->getTrace()[0]);
     }

--- a/src/Models/Backup.php
+++ b/src/Models/Backup.php
@@ -65,8 +65,18 @@ class Backup extends Model
     public function backup()
     {
         return new \Spatie\Backup\BackupDestination\Backup(
-            Storage::disk($this->disk),
-            $this->location
-        );
+            Storage::disk($this->disk), $this->location);
+    }
+
+    /**
+     * Resolves Backup Model.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * 
+     * @return \Fusion\Models\Backup
+     */
+    public static function resolve($name, $disk)
+    {
+        return static::where(['name' => $name, 'disk' => $disk])->firstOrFail();
     }
 }

--- a/tests/src/Feature/Backups/BackupTest.php
+++ b/tests/src/Feature/Backups/BackupTest.php
@@ -383,4 +383,18 @@ class BackupTest extends TestBase
             );
         }
     }
+
+    // ------------------------------------------------
+    // NOTIFICATIONS
+    // ------------------------------------------------
+
+    /** @test */
+    public function successful_backup_will_notify_user_with_valid_mail_settings()
+    {
+        $backup = $this->newBackup();
+
+        \Notification::assertSentTo(
+            app(config('backup.notifications.notifiable')),
+            'Spatie\Backup\Notifications\Notifications\BackupWasSuccessful');
+    }
 }

--- a/tests/src/Feature/Backups/RestoreTest.php
+++ b/tests/src/Feature/Backups/RestoreTest.php
@@ -121,7 +121,7 @@ class RestoreTest extends TestBase
 
         RestoreFromBackup::dispatchNow($backup);
 
-        Event::assertDispatched(Restore\DatabaseSuccessful::class);
+        Event::assertDispatched(Restore\UnzipSuccessful::class);
         Event::assertDispatched(Restore\ManifestWasCreated::class);
         Event::assertDispatched(Restore\DatabaseSuccessful::class);
         Event::assertDispatched(Restore\FileSuccessful::class);


### PR DESCRIPTION
### What does this implement or fix?
This update addresses the issue of successful backups being marked as failed due to errors in sending notification (e.g. invalid mail settings).

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#688](https://github.com/fusioncms/fusioncms/issues/688)

- [x] All javascript/scss resources are compiled for production