### PR TITLE
Sync `backups` database table after backup cleanup

### DIFF
--- a/src/Jobs/Backups/BackupSync.php
+++ b/src/Jobs/Backups/BackupSync.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Fusion\Jobs\Backups;
+
+use Fusion\Models\Backup;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Log;
+use Spatie\Backup\BackupDestination\BackupDestination;
+use Throwable;
+
+
+class BackupSync
+{
+    use Dispatchable;
+
+    /**
+     * @var \Spatie\Backup\BackupDestination\BackupDestination
+     */
+    public $backupDestination;
+
+    /**
+     * Creates new instance.
+     *
+     * @param \Spatie\Backup\BackupDestination\BackupDestination $backupDestination
+     */
+    public function __construct(BackupDestination $backupDestination)
+    {
+        $this->backupDestination = $backupDestination;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Backup::where(['disk' => $this->backupDestination->diskName()])
+            ->each(function($backup) {
+                if (! $backup->exists()) {
+                    $backup->delete();
+                }
+            });
+    }
+
+    /**
+     * The job failed to process.
+     *
+     * @param \Throwable $exception
+     *
+     * @return void
+     */
+    public function failed(Throwable $exception)
+    {
+        Log::error('There was an error trying to sync backups: '.$exception->getMessage(), (array) $exception->getTrace()[0]);
+    }
+}

--- a/src/Jobs/Backups/BackupSync.php
+++ b/src/Jobs/Backups/BackupSync.php
@@ -3,6 +3,7 @@
 namespace Fusion\Jobs\Backups;
 
 use Fusion\Models\Backup;
+use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Support\Facades\Log;
 use Spatie\Backup\BackupDestination\BackupDestination;
@@ -12,6 +13,7 @@ use Throwable;
 class BackupSync
 {
     use Dispatchable;
+    use Queueable;
 
     /**
      * @var \Spatie\Backup\BackupDestination\BackupDestination
@@ -35,12 +37,13 @@ class BackupSync
      */
     public function handle()
     {
-        Backup::where(['disk' => $this->backupDestination->diskName()])
-            ->each(function($backup) {
-                if (! $backup->exists()) {
-                    $backup->delete();
-                }
-            });
+        $disk = $this->backupDestination->diskName();
+
+        Backup::where(['disk' => $disk])->each(function($backup) {
+            if (! $backup->exists()) {
+                $backup->delete();
+            }
+        });
     }
 
     /**
@@ -52,6 +55,6 @@ class BackupSync
      */
     public function failed(Throwable $exception)
     {
-        Log::error('There was an error trying to sync backups: '.$exception->getMessage(), (array) $exception->getTrace()[0]);
+        Log::error('There was an error trying to sync `backups` table: '.$exception->getMessage(), (array) $exception->getTrace()[0]);
     }
 }

--- a/src/Listeners/BackupEventSubscriber.php
+++ b/src/Listeners/BackupEventSubscriber.php
@@ -153,8 +153,7 @@ class BackupEventSubscriber
      */
     public function handleCleanupSuccessful($event)
     {
-        BackupSync::dispatchNow(
-            $event->backupDestination->diskName());
+        BackupSync::dispatchNow($event->backupDestination);
     }
 
     /**
@@ -164,8 +163,8 @@ class BackupEventSubscriber
      */
     public function handleCleanupFailed($event)
     {
-        if ($disk = $event->backupDestination->diskName()) {
-            BackupSync::dispatchNow($disk);
+        if ($destination = $event->backupDestination) {
+            BackupSync::dispatchNow($destination);
         } else {
             Log::error('Backup cleanup has failed.', [
                 'message' => $event->exception->getMessage()

--- a/tests/src/Feature/Backups/CleanupTest.php
+++ b/tests/src/Feature/Backups/CleanupTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Fusion\Tests\Feature\Backups;
+
+use Fusion\Jobs\Backups\BackupSync;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Spatie\Backup\Events\CleanupHasFailed;
+use Spatie\Backup\Events\CleanupWasSuccessful;
+
+class CleanupTest extends TestBase
+{
+    /** @test */
+    public function successful_cleanup_will_run_sync_command()
+    {
+        Bus::fake();
+
+        $this->artisan('backup:clean');
+
+        Bus::assertDispatched(BackupSync::class);
+    }
+
+    /** @test */
+    public function successful_cleanup_will_fire_event()
+    {
+        Event::fake([
+            CleanupWasSuccessful::class
+        ]);
+
+        $this->artisan('backup:clean');
+
+        Event::assertDispatched(CleanupWasSuccessful::class);
+    }
+
+    /** @test */
+    public function failed_cleanup_will_fire_event()
+    {
+        Event::fake([
+            CleanupHasFailed::class
+        ]);
+
+        // invalidate..
+        config(['backup.backup.destination.disks' => ['fake-disk']]);
+
+        $this->artisan('backup:clean');
+
+        Event::assertDispatched(CleanupHasFailed::class);
+    }
+
+    /** @test */
+    public function successful_cleanup_will_notify_user_with_valid_mail_settings()
+    {
+        $this->artisan('backup:clean');
+
+        \Notification::assertSentTo(
+            app(config('backup.notifications.notifiable')),
+            'Spatie\Backup\Notifications\Notifications\CleanupWasSuccessful'
+        );
+    }
+
+    /** @test */
+    public function failed_cleanup_will_notify_user_with_valid_mail_settings()
+    {
+        // invalidate..
+        config(['backup.backup.destination.disks' => ['fake-disk']]);
+        
+        $this->artisan('backup:clean');
+
+        \Notification::assertSentTo(
+            app(config('backup.notifications.notifiable')),
+            'Spatie\Backup\Notifications\Notifications\CleanupHasFailed'
+        );
+    }
+}


### PR DESCRIPTION
### What does this implement or fix?
This update adds a new `Fusion\Jobs\Backups\BackupSync` command to sync the local database with existing backup zip files. This will automatically run after the `backup:cleanup` artisan command is run.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#689](https://github.com/fusioncms/fusioncms/issues/689)