### PR TITLE
Method renaming `builderName`

### DIFF
--- a/src/Http/Resources/FormResource.php
+++ b/src/Http/Resources/FormResource.php
@@ -35,7 +35,7 @@ class FormResource extends JsonResource
             'thankyou_template'       => $this->thankyou_template,
             'status'                  => $this->status,
 
-            'table'                   => $this->builderName(),
+            'table'                   => $this->getBuilderTable(),
             'blueprint'               => new BlueprintResource($this->blueprint),
             'responses'               => $this->responses,
         ];

--- a/src/Http/Resources/MatrixResource.php
+++ b/src/Http/Resources/MatrixResource.php
@@ -18,7 +18,7 @@ class MatrixResource extends JsonResource
         $resource = parent::toArray($request);
 
         $resource['admin_path'] = $this->adminPath;
-        $resource['table']      = $this->builderName();
+        $resource['table']      = $this->getBuilderTable();
         $resource['blueprint']  = new BlueprintResource($this->blueprint);
         $resource['parent']     = new MatrixResource($this->parent);
         $resource['children']   = MatrixResource::collection($this->whenLoaded('children'));

--- a/src/Http/Resources/NavigationResource.php
+++ b/src/Http/Resources/NavigationResource.php
@@ -21,7 +21,7 @@ class NavigationResource extends JsonResource
             'handle'      => $this->handle,
             'description' => $this->description,
 
-            'table'       => $this->builderName(),
+            'table'       => $this->getBuilderTable(),
             'blueprint'   => new BlueprintResource($this->blueprint),
             'nodes'       => NodeResource::collection($this->nodes),
         ];

--- a/src/Http/Resources/TaxonomyResource.php
+++ b/src/Http/Resources/TaxonomyResource.php
@@ -22,7 +22,7 @@ class TaxonomyResource extends JsonResource
             'slug'             => $this->slug,
             'description'      => $this->description,
             'admin_path'       => $this->adminPath,
-            'table'            => $this->builderName(),
+            'table'            => $this->getBuilderTable(),
 
             'sidebar'          => $this->sidebar,
             'icon'             => $this->icon,

--- a/src/Models/Fieldset.php
+++ b/src/Models/Fieldset.php
@@ -30,7 +30,7 @@ class Fieldset extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "fx_{$this->handle}";
     }

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -78,7 +78,7 @@ class Form extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "form_{$this->handle}";
     }

--- a/src/Models/Matrix.php
+++ b/src/Models/Matrix.php
@@ -83,7 +83,7 @@ class Matrix extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "mx_{$this->handle}";
     }

--- a/src/Models/Navigation.php
+++ b/src/Models/Navigation.php
@@ -46,7 +46,7 @@ class Navigation extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "navigation_{$this->handle}";
     }

--- a/src/Models/Section.php
+++ b/src/Models/Section.php
@@ -59,8 +59,8 @@ class Section extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
-        return $this->blueprint->blueprintable->builderName();
+        return $this->blueprint->blueprintable->getBuilderTable();
     }
 }

--- a/src/Models/Setting.php
+++ b/src/Models/Setting.php
@@ -52,7 +52,7 @@ class Setting extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "settings_{$this->handle}";
     }

--- a/src/Models/Taxonomy.php
+++ b/src/Models/Taxonomy.php
@@ -57,7 +57,7 @@ class Taxonomy extends Model
      *
      * @return string
      */
-    public function builderName()
+    public function getBuilderTable()
     {
         return "taxonomy_{$this->handle}";
     }

--- a/src/Observers/FieldObserver.php
+++ b/src/Observers/FieldObserver.php
@@ -19,7 +19,7 @@ class FieldObserver
         $fieldtype = fieldtypes()->get($field->type);
         $fieldtype->onSaved($field);
 
-        $tablename = $field->fieldable->builderName();
+        $tablename = $field->fieldable->getBuilderTable();
         $column    = $fieldtype->getColumn('type');
         $settings  = $fieldtype->getColumn('settings') ?? [];
 
@@ -64,7 +64,7 @@ class FieldObserver
         if ($old['handle'] !== $new['handle']) {
             if (!is_null($new['column'])) {
                 Schema::table(
-                    $field->fieldable->builderName(),
+                    $field->fieldable->getBuilderTable(),
                     function ($table) use ($old, $new) {
                         $table->renameColumn($old['handle'], $new['handle']);
                     }
@@ -78,7 +78,7 @@ class FieldObserver
         if ($old['type'] !== $new['type']) {
             if (!is_null($new['column'])) {
                 Schema::table(
-                    $field->fieldable->builderName(),
+                    $field->fieldable->getBuilderTable(),
                     function ($table) use ($new) {
                         call_user_func_array([$table, $new['column']], [$new['handle']])->change();
                     }
@@ -111,7 +111,7 @@ class FieldObserver
         $fieldtype = fieldtypes()->get($field->type);
         $column    = $fieldtype->getColumn('type');
 
-        $tablename = $field->fieldable->builderName();
+        $tablename = $field->fieldable->getBuilderTable();
 
         if (!is_null($column)) {
             if (Schema::hasColumn($tablename, $field->handle)) {

--- a/src/Observers/FieldsetObserver.php
+++ b/src/Observers/FieldsetObserver.php
@@ -17,7 +17,7 @@ class FieldsetObserver
      */
     public function created(Fieldset $fieldset)
     {
-        Schema::create($fieldset->builderName(), function (Blueprint $table) {
+        Schema::create($fieldset->getBuilderTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('field_id');
             $table->unsignedBigInteger('fieldset_id');
@@ -44,8 +44,8 @@ class FieldsetObserver
     {
         $old = Fieldset::find($fieldset->id);
 
-        if ($old->builderName() !== $fieldset->builderName()) {
-            Schema::rename($old->builderName(), $fieldset->builderName());
+        if ($old->getBuilderTable() !== $fieldset->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $fieldset->getBuilderTable());
         }
     }
 
@@ -58,6 +58,6 @@ class FieldsetObserver
      */
     public function deleted(Fieldset $fieldset)
     {
-        Schema::dropIfExists($fieldset->builderName());
+        Schema::dropIfExists($fieldset->getBuilderTable());
     }
 }

--- a/src/Observers/FormObserver.php
+++ b/src/Observers/FormObserver.php
@@ -18,7 +18,7 @@ class FormObserver
      */
     public function created(Form $form)
     {
-        Schema::create($form->builderName(), function (Blueprint $table) {
+        Schema::create($form->getBuilderTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('form_id');
 
@@ -39,8 +39,8 @@ class FormObserver
     {
         $old = Form::find($form->id);
 
-        if ($old->builderName() !== $form->builderName()) {
-            Schema::rename($old->builderName(), $form->builderName());
+        if ($old->getBuilderTable() !== $form->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $form->getBuilderTable());
         }
     }
 
@@ -53,7 +53,7 @@ class FormObserver
      */
     public function deleted(Form $form)
     {
-        Schema::dropIfExists($form->builderName());
+        Schema::dropIfExists($form->getBuilderTable());
     }
 
     /**

--- a/src/Observers/MatrixObserver.php
+++ b/src/Observers/MatrixObserver.php
@@ -20,7 +20,7 @@ class MatrixObserver
      */
     public function created(Matrix $matrix)
     {
-        Schema::create($matrix->builderName(), function (Blueprint $table) use ($matrix) {
+        Schema::create($matrix->getBuilderTable(), function (Blueprint $table) use ($matrix) {
             if ($matrix->type === 'collection') {
                 $table->bigIncrements('id');
             }
@@ -49,8 +49,8 @@ class MatrixObserver
         $old = Matrix::find($matrix->id);
 
         // Rename the tables if changed
-        if ($old->builderName() !== $matrix->builderName()) {
-            Schema::rename($old->builderName(), $matrix->builderName());
+        if ($old->getBuilderTable() !== $matrix->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $matrix->getBuilderTable());
 
             $oldClass = 'Fusion\\Models\\Collections\\'.Str::studly($old->handle);
             $newClass = 'Fusion\\Models\\Collections\\'.Str::studly($matrix->handle);
@@ -65,14 +65,14 @@ class MatrixObserver
 
         // Create the ID column if converting from a single to a collection type
         if ($old->type === 'single' and $matrix->type === 'collection') {
-            Schema::table($matrix->builderName(), function (Blueprint $table) {
+            Schema::table($matrix->getBuilderTable(), function (Blueprint $table) {
                 $table->bigIncrements('id')->first();
             });
         }
 
         // Drop the ID column if converting from a collection to a single type
         if ($old->type === 'collection' and $matrix->type === 'single') {
-            Schema::table($matrix->builderName(), function (Blueprint $table) {
+            Schema::table($matrix->getBuilderTable(), function (Blueprint $table) {
                 $table->dropColumn('id');
             });
         }
@@ -87,6 +87,6 @@ class MatrixObserver
      */
     public function deleted(Matrix $matrix)
     {
-        Schema::dropIfExists($matrix->builderName());
+        Schema::dropIfExists($matrix->getBuilderTable());
     }
 }

--- a/src/Observers/NavigationObserver.php
+++ b/src/Observers/NavigationObserver.php
@@ -17,7 +17,7 @@ class NavigationObserver
      */
     public function created(Navigation $navigation)
     {
-        Schema::create($navigation->builderName(), function (Blueprint $table) {
+        Schema::create($navigation->getBuilderTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('navigation_id')->index();
             $table->unsignedBigInteger('parent_id')->index()->default(0);
@@ -42,8 +42,8 @@ class NavigationObserver
     {
         $old = Navigation::find($navigation->id);
 
-        if ($old->builderName() !== $navigation->builderName()) {
-            Schema::rename($old->builderName(), $navigation->builderName());
+        if ($old->getBuilderTable() !== $navigation->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $navigation->getBuilderTable());
         }
     }
 
@@ -56,6 +56,6 @@ class NavigationObserver
      */
     public function deleted(Navigation $navigation)
     {
-        Schema::dropIfExists($navigation->builderName());
+        Schema::dropIfExists($navigation->getBuilderTable());
     }
 }

--- a/src/Observers/SettingObserver.php
+++ b/src/Observers/SettingObserver.php
@@ -18,7 +18,7 @@ class SettingObserver
      */
     public function created(Setting $setting)
     {
-        Schema::create($setting->builderName(), function (Blueprint $table) {
+        Schema::create($setting->getBuilderTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('setting_id')->index();
             $table->timestamps();
@@ -36,8 +36,8 @@ class SettingObserver
     {
         $old = Setting::find($setting->id);
 
-        if ($old->builderName() !== $setting->builderName()) {
-            Schema::rename($old->builderName(), $setting->builderName());
+        if ($old->getBuilderTable() !== $setting->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $setting->getBuilderTable());
 
             $oldClass = 'Fusion\\Models\\Settings\\'.Str::studly($old->handle);
             $newClass = 'Fusion\\Models\\Settings\\'.Str::studly($setting->handle);
@@ -53,6 +53,6 @@ class SettingObserver
      */
     public function deleted(Setting $setting)
     {
-        Schema::dropIfExists($setting->builderName());
+        Schema::dropIfExists($setting->getBuilderTable());
     }
 }

--- a/src/Observers/TaxonomyObserver.php
+++ b/src/Observers/TaxonomyObserver.php
@@ -17,7 +17,7 @@ class TaxonomyObserver
      */
     public function created(Taxonomy $taxonomy)
     {
-        Schema::create($taxonomy->builderName(), function (Blueprint $table) {
+        Schema::create($taxonomy->getBuilderTable(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('taxonomy_id');
             $table->unsignedBigInteger('parent_id')->nullable();
@@ -45,8 +45,8 @@ class TaxonomyObserver
         $old = Taxonomy::find($taxonomy->id);
 
         // Rename the tables if changed
-        if ($old->builderName() !== $taxonomy->builderName()) {
-            Schema::rename($old->builderName(), $taxonomy->builderName());
+        if ($old->getBuilderTable() !== $taxonomy->getBuilderTable()) {
+            Schema::rename($old->getBuilderTable(), $taxonomy->getBuilderTable());
         }
     }
 
@@ -59,6 +59,6 @@ class TaxonomyObserver
      */
     public function deleted(Taxonomy $taxonomy)
     {
-        Schema::dropIfExists($taxonomy->builderName());
+        Schema::dropIfExists($taxonomy->getBuilderTable());
     }
 }

--- a/tests/src/Feature/BlueprintTest.php
+++ b/tests/src/Feature/BlueprintTest.php
@@ -32,7 +32,7 @@ class BlueprintTest extends TestCase
     {
         $this->matrix->blueprint->fields->each(function ($field) {
             $this->assertDatabaseTableHasColumn(
-                $this->matrix->builderName(),
+                $this->matrix->getBuilderTable(),
                 $field->handle
             );
         });
@@ -50,7 +50,7 @@ class BlueprintTest extends TestCase
              ]);
 
         $this->assertDatabaseTableHasColumn(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'excerpt'
         );
     }
@@ -63,7 +63,7 @@ class BlueprintTest extends TestCase
              ->delete();
 
         $this->assertDatabaseTableDoesNotHaveColumn(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content'
         );
     }
@@ -79,12 +79,12 @@ class BlueprintTest extends TestCase
              ]);
 
         $this->assertDatabaseTableHasColumn(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'story'
         );
 
         $this->assertDatabaseTableDoesNotHaveColumn(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content'
         );
     }
@@ -93,7 +93,7 @@ class BlueprintTest extends TestCase
     public function when_a_fields_fieldtype_is_changed_the_associated_database_columns_type_should_also_change()
     {
         $this->assertDatabaseTableColumnHasType(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content',
             'string'
         );
@@ -107,7 +107,7 @@ class BlueprintTest extends TestCase
              ]);
 
         $this->assertDatabaseTableColumnHasType(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content',
             'text'
         );
@@ -117,7 +117,7 @@ class BlueprintTest extends TestCase
     public function when_field_is_replaced_with_same_name_field_the_database_column_should_update_accordingly()
     {
         $this->assertDatabaseTableColumnHasType(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content',
             'string'
         );
@@ -137,7 +137,7 @@ class BlueprintTest extends TestCase
              ]);
 
         $this->assertDatabaseTableColumnHasType(
-            $this->matrix->builderName(),
+            $this->matrix->getBuilderTable(),
             'content',
             'text'
         );
@@ -146,7 +146,7 @@ class BlueprintTest extends TestCase
     /** @test */
     public function when_a_field_is_renamed_and_new_field_created_in_its_name_database_should_have_both_columns()
     {
-        $table     = $this->matrix->builderName();
+        $table     = $this->matrix->getBuilderTable();
         $blueprint = $this->matrix->blueprint;
         $section   = $blueprint->sections->first();
         $fieldA    = $section->fields->first();

--- a/tests/src/Feature/FieldsetTest.php
+++ b/tests/src/Feature/FieldsetTest.php
@@ -110,7 +110,7 @@ class FieldsetTest extends TestCase
     /** @test */
     public function a_user_with_permissions_can_delete_a_fieldset()
     {
-        $table = $this->fieldset->builderName();
+        $table = $this->fieldset->getBuilderTable();
 
         $this
             ->actingAs($this->owner, 'api')
@@ -164,7 +164,7 @@ class FieldsetTest extends TestCase
     {
         $this->fieldset->fields->each(function ($field) {
             $this->assertDatabaseTableHasColumn(
-                $this->fieldset->builderName(),
+                $this->fieldset->getBuilderTable(),
                 $field->handle
             );
         });
@@ -181,12 +181,12 @@ class FieldsetTest extends TestCase
             ]);
 
         $this->assertDatabaseTableHasColumn(
-            $this->fieldset->builderName(),
+            $this->fieldset->getBuilderTable(),
             'e_mail'
         );
 
         $this->assertDatabaseTableDoesNotHaveColumn(
-            $this->fieldset->builderName(),
+            $this->fieldset->getBuilderTable(),
             'email'
         );
     }
@@ -199,7 +199,7 @@ class FieldsetTest extends TestCase
             ->delete();
 
         $this->assertDatabaseTableDoesNotHaveColumn(
-            $this->fieldset->builderName(),
+            $this->fieldset->getBuilderTable(),
             'phone'
         );
     }

--- a/tests/src/Feature/Fieldtypes/FieldsetFieldtypeTest.php
+++ b/tests/src/Feature/Fieldtypes/FieldsetFieldtypeTest.php
@@ -66,7 +66,7 @@ class FieldsetFieldtypeTest extends TestCase
             ])
             ->assertStatus(201);
 
-        $this->assertDatabaseHas($this->fieldset->builderName(), [
+        $this->assertDatabaseHas($this->fieldset->getBuilderTable(), [
             'field_id'          => $this->field->id,
             'fieldset_id'       => $this->fieldset->id,
             'fieldsetable_id'   => $this->model->first()->id,

--- a/tests/src/Feature/Fieldtypes/FileFieldtypeTest.php
+++ b/tests/src/Feature/Fieldtypes/FileFieldtypeTest.php
@@ -68,7 +68,7 @@ class FileFieldtypeTest extends TestCase
             'extension'    => 'png',
         ]);
 
-        $this->assertDatabaseHas($this->matrix->builderName(), [
+        $this->assertDatabaseHas($this->matrix->getBuilderTable(), [
             'name' => $attributes['name'],
             'slug' => $attributes['slug'],
         ]);

--- a/tests/src/Feature/Fieldtypes/FormFieldtypeTest.php
+++ b/tests/src/Feature/Fieldtypes/FormFieldtypeTest.php
@@ -56,7 +56,7 @@ class FormFieldtypeTest extends TestCase
 
         $entry = $this->model->first();
 
-        $this->assertDatabaseHas($this->matrix->builderName(), [
+        $this->assertDatabaseHas($this->matrix->getBuilderTable(), [
             'name' => $attributes['name'],
             'slug' => $attributes['slug'],
         ]);

--- a/tests/src/Feature/Forms/FormTest.php
+++ b/tests/src/Feature/Forms/FormTest.php
@@ -47,7 +47,7 @@ class FormTest extends TestCase
         $form = Form::firstOrFail();
 
         // assert response table exists..
-        $this->assertDatabaseHasTable($form->builderName());
+        $this->assertDatabaseHasTable($form->getBuilderTable());
 
         // assert associated blueprint exists..
         $this->assertDatabaseHas('blueprints', [
@@ -204,7 +204,7 @@ class FormTest extends TestCase
         ]);
 
         // assert response table exists..
-        $this->assertDatabaseDoesNotHaveTable($form->builderName());
+        $this->assertDatabaseDoesNotHaveTable($form->getBuilderTable());
     }
 
     /** @test */
@@ -238,7 +238,7 @@ class FormTest extends TestCase
             ->be($this->guest)
             ->post($form->path());
 
-        $this->assertDatabaseMissing($form->builderName(), [
+        $this->assertDatabaseMissing($form->getBuilderTable(), [
             'form_id'                 => $form->id,
             'identifiable_ip_address' => '127.0.0.1',
         ]);
@@ -254,7 +254,7 @@ class FormTest extends TestCase
             ->be($this->guest)
             ->post($form->path());
 
-        $this->assertDatabaseHas($form->builderName(), [
+        $this->assertDatabaseHas($form->getBuilderTable(), [
             'form_id'                 => $form->id,
             'identifiable_ip_address' => '127.0.0.1',
         ]);
@@ -272,7 +272,7 @@ class FormTest extends TestCase
             ->be($this->user)
             ->post($form->path(), ['identifiable_email_address' => $this->user->email]);
 
-        $this->assertDatabaseHas($form->builderName(), [
+        $this->assertDatabaseHas($form->getBuilderTable(), [
             'form_id'                    => $form->id,
             'identifiable_email_address' => $this->user->email,
         ]);

--- a/tests/src/Feature/Matrix/MatrixTest.php
+++ b/tests/src/Feature/Matrix/MatrixTest.php
@@ -192,7 +192,7 @@ class MatrixTest extends TestCase
         $name = $entry->id.' '.$entry->created_at->format('Y');
         $slug = Str::slug($name);
 
-        $this->assertDatabaseHas($matrix->builderName(), [
+        $this->assertDatabaseHas($matrix->getBuilderTable(), [
             'name' => $name,
             'slug' => $slug,
         ]);

--- a/tests/src/Feature/Navigation/NavigationTest.php
+++ b/tests/src/Feature/Navigation/NavigationTest.php
@@ -178,7 +178,7 @@ class NavigationTest extends TestCase
             'before' => $nodeOne->id,
         ]);
 
-        $this->assertDatabaseHas($navigation->builderName(), [
+        $this->assertDatabaseHas($navigation->getBuilderTable(), [
             'name'  => $nodeTwo->name,
             'order' => 0.0,
         ]);
@@ -217,7 +217,7 @@ class NavigationTest extends TestCase
             'after' => $nodeTwo->id,
         ]);
 
-        $this->assertDatabaseHas($navigation->builderName(), [
+        $this->assertDatabaseHas($navigation->getBuilderTable(), [
             'name'  => $nodeOne->name,
             'order' => 2.5,
         ]);
@@ -258,9 +258,9 @@ class NavigationTest extends TestCase
 
         $this->json('PATCH', '/api/navigation/'.$navigation->id.'/nodes/refresh');
 
-        $this->assertDatabaseHas($navigation->builderName(), ['name' => $nodeTwo->name, 'order' => 1]);
-        $this->assertDatabaseHas($navigation->builderName(), ['name' => $nodeOne->name, 'order' => 2]);
-        $this->assertDatabaseHas($navigation->builderName(), ['name' => $nodeThree->name, 'order' => 3]);
+        $this->assertDatabaseHas($navigation->getBuilderTable(), ['name' => $nodeTwo->name, 'order' => 1]);
+        $this->assertDatabaseHas($navigation->getBuilderTable(), ['name' => $nodeOne->name, 'order' => 2]);
+        $this->assertDatabaseHas($navigation->getBuilderTable(), ['name' => $nodeThree->name, 'order' => 3]);
     }
 
     /** @test */


### PR DESCRIPTION
### What does this implement or fix?
This update renames all `builderName()` method references to `getBuilderTable()`.

### Does this close any currently open issues?
- resolves [fusioncms/fusioncms#704](https://github.com/fusioncms/fusioncms/issues/704)