### PR TITLE
Quick fix: unassigned mailer errors

### DIFF
--- a/src/Concerns/MustVerifyEmail.php
+++ b/src/Concerns/MustVerifyEmail.php
@@ -3,6 +3,7 @@
 namespace Fusion\Concerns;
 
 use Illuminate\Auth\Notifications\VerifyEmail;
+use Throwable;
 
 trait MustVerifyEmail
 {
@@ -62,7 +63,11 @@ trait MustVerifyEmail
     public function sendEmailVerificationNotification()
     {
         if ($this->shouldVerifyEmail()) {
-            $this->notify(new VerifyEmail());
+            rescue(function() {
+                $this->notify(new VerifyEmail());
+            }, function(Throwable $exception) {
+                logger()->error("Unable to send email verification: `{$exception->getMessage()}`");
+            });
         }
     }
 

--- a/src/Http/Controllers/API/Users/UserController.php
+++ b/src/Http/Controllers/API/Users/UserController.php
@@ -67,15 +67,17 @@ class UserController extends Controller
             $user->syncSubscriptions($attributes['subscriptions']);
         }
 
-        /**
-         * Forces new users to confirm themselves.
-         *
-         * Via:
-         * - Verifying their e-mail address.
-         * - Setting their own password.
-         */
-        Mail::to($user)
-            ->send(new ConfirmNewUser($user));
+        rescue(function() use ($user) {
+            /**
+             * Forces new users to confirm themselves.
+             *
+             * Via:
+             * - Verifying their e-mail address.
+             * - Setting their own password.
+             */
+            Mail::to($user)
+                ->send(new ConfirmNewUser($user));
+        });
 
         return new UserResource($user);
     }


### PR DESCRIPTION
### What does this implement or fix?
Suppress breaking error messages when FusionCMS is first installed and mailer settings haven't been setup yet.
