### PR TITLE
Fix validation and rules for fieldset

### DIFF
--- a/src/Fieldtypes/FieldsetFieldtype.php
+++ b/src/Fieldtypes/FieldsetFieldtype.php
@@ -76,7 +76,7 @@ class FieldsetFieldtype extends Fieldtype
             $name  = "{$fieldset->handle}.{$field->handle}";
             $value = $field->type()->attributes($field, $value ? $value[$field->handle] : null);
 
-            return [$name => $value[$field->handle]];
+            return [$name => ($value[$field->handle] ?? $field->name)];
         });
     }
 
@@ -96,7 +96,7 @@ class FieldsetFieldtype extends Fieldtype
             $name = "{$fieldset->handle}.{$field->handle}";
             $rule = $field->type()->rules($field, $value ? $value[$field->handle] : null);
 
-            return [$name => $rule[$field->handle] ?: 'sometimes'];
+            return [$name => ($rule[$field->handle] ?? 'sometimes')];
         });
     }
 


### PR DESCRIPTION
### What does this implement or fix?
Adds a `??` check when looking at validation rules for fields in fieldsets to accommodate fieldtypes with sub-fields (like the `button` fieldtype).

### Does this close any currently open issues?
- fusioncms/fusioncms#763