### PR TITLE
New script order now has last order + 1

### DIFF
--- a/src/Http/Requests/ScriptRequest.php
+++ b/src/Http/Requests/ScriptRequest.php
@@ -47,7 +47,7 @@ class ScriptRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->orderLast(),
         ]);
     }
 


### PR DESCRIPTION
### What does this implement or fix?
New script order now has last order + 1

### Does this close any currently open issues?
- fusioncms/fusioncms#784

### Screenshots
<img width="1440" alt="Screen Shot 2021-10-27 at 2 50 38 PM" src="https://user-images.githubusercontent.com/28682169/139152559-a4a52c6f-e55a-4d36-b4cb-ec590814f943.png">

- [x] All javascript/scss resources are compiled for production