### PR TITLE
Order now starts at 0 for collections and links

### DIFF
--- a/src/Concerns/HasOrder.php
+++ b/src/Concerns/HasOrder.php
@@ -22,7 +22,7 @@ trait HasOrder
             ->first();
 
         if (!$last) {
-            return 1;
+            return 0;
         }
 
         return $last->order + 1;


### PR DESCRIPTION
### What does this implement or fix?
Order now starts at 0 for collections and links

### Does this close any currently open issues?
- fusioncms/fusioncms#779

### Screenshots
<img width="1440" alt="Screen Shot 2021-10-27 at 4 23 17 PM" src="https://user-images.githubusercontent.com/28682169/139161672-6e6eb327-b5ce-4edb-8e77-8769972d881b.png">

- [x] All javascript/scss resources are compiled for production