### PR TITLE
Fixing order updating after an edit

### DIFF
--- a/src/Http/Requests/CollectionRequest.php
+++ b/src/Http/Requests/CollectionRequest.php
@@ -37,6 +37,16 @@ class CollectionRequest extends Request
     }
 
     /**
+     * Helper function to find the last order
+     *
+     * @return float
+     */
+    public function orderLast()
+    {
+        return $this->model->count();
+    }
+
+    /**
      * Prepare the data for validation.
      *
      * @return void
@@ -45,7 +55,7 @@ class CollectionRequest extends Request
     {
         $this->merge([
             'matrix_id'  => $this->matrix->id,
-            'order'         => $this->order ?? $this->model->orderLast(),
+            'order'         => $this->model->find($this->id)->order ?? $this->orderLast(),
             'status'     => $this->status ?? true,
             'publish_at' => (isset($this->publish_at) and !empty($this->publish_at)) ? $this->publish_at : now(),
             'expire_at'  => (isset($this->expire_at) and !empty($this->expire_at)) ? $this->expire_at : null,

--- a/src/Http/Requests/DiskRequest.php
+++ b/src/Http/Requests/DiskRequest.php
@@ -48,7 +48,7 @@ class DiskRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->disk->order ?? $this->orderLast(),
         ]);
     }
 

--- a/src/Http/Requests/FieldsetRequest.php
+++ b/src/Http/Requests/FieldsetRequest.php
@@ -49,7 +49,7 @@ class FieldsetRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->fieldset->order ?? $this->orderLast(),
         ]);
     }
 

--- a/src/Http/Requests/FormRequest.php
+++ b/src/Http/Requests/FormRequest.php
@@ -51,7 +51,7 @@ class FormRequest extends Request
     {
         $this->merge([
             'slug' => $this->slug ?? Str::slug($this->name),
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->form->order ?? $this->orderLast(),
         ]);
     }
 

--- a/src/Http/Requests/MatrixRequest.php
+++ b/src/Http/Requests/MatrixRequest.php
@@ -51,7 +51,7 @@ class MatrixRequest extends Request
     {
         $this->merge([
             'slug'   => $this->slug ?? Str::slug($this->name),
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->matrix->order ?? $this->orderLast(),
             'status' => $this->status ?? true,
         ]);
     }

--- a/src/Http/Requests/NavigationRequest.php
+++ b/src/Http/Requests/NavigationRequest.php
@@ -49,7 +49,7 @@ class NavigationRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'order'         => $this->order ?? $this->orderLast(),
+            'order'         => $this->navigation->order ?? $this->orderLast(),
         ]);
     }
 

--- a/src/Http/Requests/ScriptRequest.php
+++ b/src/Http/Requests/ScriptRequest.php
@@ -47,7 +47,7 @@ class ScriptRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'order'         => $this->orderLast(),
+            'order'         => $this->script->order ?? $this->orderLast(),
         ]);
     }
 

--- a/src/Http/Requests/TaxonomyRequest.php
+++ b/src/Http/Requests/TaxonomyRequest.php
@@ -50,8 +50,8 @@ class TaxonomyRequest extends Request
     protected function prepareForValidation()
     {
         $this->merge([
-            'slug' => $this->slug ?? Str::slug($this->name),
-            'order'         => $this->order ?? $this->orderLast(),
+            'slug'           => $this->slug ?? Str::slug($this->name),
+            'order'         => $this->taxonomy->order ?? $this->orderLast(),
         ]);
     }
 


### PR DESCRIPTION
### What does this implement or fix?
Fixing order updating after an edit

### Does this close any currently open issues?
- fusioncms/fusioncms#785

### Screenshots
<img width="1680" alt="Screen Shot 2021-11-16 at 3 19 13 PM" src="https://user-images.githubusercontent.com/28682169/142081647-f3921774-aeb7-47bb-b7d8-292ee9aca4aa.png">


- [ ] All javascript/scss resources are compiled for production