### PR TITLE
Able to have a Taxonomy and a Matrix with the same handle in sidebar

### DIFF
--- a/src/Providers/MenuServiceProvider.php
+++ b/src/Providers/MenuServiceProvider.php
@@ -73,14 +73,14 @@ class MenuServiceProvider extends ServiceProvider
                     $handle = str_handle($name);
                     $path   = $subitem->adminPath;
 
-                    return [$handle => ['title' => $name, 'to' => $path]];
+                    return ['matrix-' . $handle => ['title' => $name, 'to' => $path]];
                 });
 
                 $name   = $item->name;
                 $handle = str_handle($name);
                 $path   = $item->adminPath;
 
-                return [$item->handle => [
+                return ['matrix-' . $item->handle => [
                     'title'    => $item->name,
                     'icon'     => $item->icon ?: 'pencil-alt',
                     'children' => collect([
@@ -89,7 +89,7 @@ class MenuServiceProvider extends ServiceProvider
                 ]];
             }
 
-            return [$item->handle => [
+            return ['matrix-' . $item->handle => [
                 'title' => $item->name,
                 'to'    => $item->adminPath,
                 'icon'  => $item->icon ?: 'pencil-alt',
@@ -105,7 +105,7 @@ class MenuServiceProvider extends ServiceProvider
         $taxonomies = Taxonomy::where('sidebar', true)->orderBy('name')->get();
         if ($taxonomies->isNotEmpty()) {
             $taxonomies = $taxonomies->mapWithKeys(function ($item) {
-                return [$item->handle => [
+                return ['taxonomy-' . $item->handle => [
                     'title' => $item->name,
                     'to'    => $item->adminPath,
                     'icon'  => $item->icon ?: 'tag',


### PR DESCRIPTION
### What does this implement or fix?
Able to have a Taxonomy and a Matrix with the same handle in sidebar

### Does this close any currently open issues?
- fusioncms/fusioncms#786

### Screenshots
<img width="1680" alt="Screen Shot 2021-11-16 at 4 14 28 PM" src="https://user-images.githubusercontent.com/28682169/142086329-ff29b5f2-c080-431b-8db2-f2f8515faee8.png">


- [x] All javascript/scss resources are compiled for production