### PR TITLE
Sparkpost secret now saves, can send email without secret in .env

### DIFF
--- a/settings/mail.php
+++ b/settings/mail.php
@@ -41,6 +41,7 @@ return [
                 'description' => 'The host name of your SMTP server.',
                 'default'     => 'smtp.example.com',
                 'override'    => 'mail.mailers.smtp.host',
+                'required'    => true,
             ],
             [
                 'name'        => 'Port',
@@ -48,18 +49,23 @@ return [
                 'description' => 'The port number of your SMTP server.',
                 'default'     => '587',
                 'override'    => 'mail.mailers.smtp.port',
+                'required'    => true,
             ],
             [
                 'name'        => 'SMTP Username',
                 'handle'      => 'mail_smtp_username',
                 'description' => 'The username for your SMTP server.',
+                'default'     => 'username',
                 'override'    => 'mail.mailers.smtp.username',
+                'required'    => true,
             ],
             [
                 'name'        => 'SMTP Password',
                 'handle'      => 'mail_smtp_password',
                 'description' => 'The password for your SMTP server.',
+                'default'     => 'password',
                 'override'    => 'mail.mailers.smtp.password',
+                'required'    => true,
             ],
         ],
         'Sparkpost' => [
@@ -67,6 +73,8 @@ return [
                 'name'        => 'Secret',
                 'handle'      => 'mail_sparkpost_secret',
                 'description' => 'Secret key assigned after setting up your SparkPost account.',
+                'default'     => 'secret',
+                'required'    => true,
             ],
         ],
         'Mailgun' => [
@@ -74,11 +82,15 @@ return [
                 'name'        => 'Domain',
                 'handle'      => 'mail_mailgun_domain',
                 'description' => 'Domain of your Mailgun account.',
+                'default'     => 'domain',
+                'required'    => true,
             ],
             [
                 'name'        => 'Secret',
                 'handle'      => 'mail_mailgun_secret',
                 'description' => 'Secret key assigned after setting up your Mailgun account.',
+                'default'     => 'secret',
+                'required'    => true,
             ],
         ],
         'Mandrill' => [
@@ -86,6 +98,8 @@ return [
                 'name'        => 'Secret',
                 'handle'      => 'mail_mandrill_secret',
                 'description' => 'Secret key assigned after setting up your Mandrill account.',
+                'default'     => 'secret',
+                'required'    => true,
             ],
         ],
         'Subjects' => [

--- a/src/Http/Controllers/API/SettingController.php
+++ b/src/Http/Controllers/API/SettingController.php
@@ -78,6 +78,8 @@ class SettingController extends Controller
      */
     public function sendTestEmail(Request $request, $test_email)
     {
+        config(['services.sparkpost.secret' => setting('mail.mail_sparkpost_secret')]);
+
         $data = array();
         Mail::send('emails/test', $data, function($message) use ($test_email) {
             $message->to($test_email, setting('mail.mail_name'))->subject('Test Email');


### PR DESCRIPTION
### What does this implement or fix?
Sparkpost secret now saves, can send email without secret in .env, just need it in settings

### Does this close any currently open issues?
- fusioncms/fusioncms#795

### Screenshots
<img width="1680" alt="Screen Shot 2021-12-08 at 1 24 02 PM" src="https://user-images.githubusercontent.com/28682169/145286525-72637f87-478c-4acc-8f59-fa3113085c29.png">


- [x] All javascript/scss resources are compiled for production