### PR TITLE
Fix so that app config will overwrite fusion config

### DIFF
--- a/src/Providers/ConfigServiceProvider.php
+++ b/src/Providers/ConfigServiceProvider.php
@@ -116,8 +116,8 @@ class ConfigServiceProvider extends ServiceProvider
             $this->app['config']->set(
                 $name,
                 Arr::mergeDeep(
-                    $this->app['config']->get($name, []),
                     require $path,
+                    $this->app['config']->get($name, []),
                 )
             );
         }

--- a/src/Providers/ConfigServiceProvider.php
+++ b/src/Providers/ConfigServiceProvider.php
@@ -44,24 +44,10 @@ class ConfigServiceProvider extends ServiceProvider
      */
     protected function registerMailServices()
     {
-        $this->app['config']['services'] = [
-
-            // SparkPost service settings..
-            'sparkpost' => [
-                'secret' => setting('mail.mail_sparkpost_secret'),
-            ],
-
-            // Mailgun service settings..
-            'mailgun' => [
-                'domain' => setting('mail.mail_mailgun_domain'),
-                'secret' => setting('mail.mail_mailgun_secret'),
-            ],
-
-            // Mandrill service settings..
-            'mandrill' => [
-                'secret' => setting('mail.mail_mandrill_secret'),
-            ],
-        ];
+		config(['sparkpost.secret' => setting('mail.mail_sparkpost_secret')]);
+		config(['mailgun.domain' => setting('mail.mail_mailgun_domain')]);
+		config(['mailgun.secret' => setting('mail.mail_mailgun_secret')]);
+		config(['mandrill.secret' => setting('mail.mail_mandrill_secret')]);
     }
 
     /**

--- a/src/Providers/ConfigServiceProvider.php
+++ b/src/Providers/ConfigServiceProvider.php
@@ -67,7 +67,6 @@ class ConfigServiceProvider extends ServiceProvider
 
                 if (is_array($value) && is_array($arr2[$key])) {
                     $output[$key] = Arr::mergeDeep($value, $arr2[$key]);
-                    $output[$key] = array_unique($output[$key], SORT_REGULAR);
                 }
             }
 

--- a/src/Providers/ConfigServiceProvider.php
+++ b/src/Providers/ConfigServiceProvider.php
@@ -44,10 +44,10 @@ class ConfigServiceProvider extends ServiceProvider
      */
     protected function registerMailServices()
     {
-		config(['sparkpost.secret' => setting('mail.mail_sparkpost_secret')]);
-		config(['mailgun.domain' => setting('mail.mail_mailgun_domain')]);
-		config(['mailgun.secret' => setting('mail.mail_mailgun_secret')]);
-		config(['mandrill.secret' => setting('mail.mail_mandrill_secret')]);
+		config(['services.sparkpost.secret' => setting('mail.mail_sparkpost_secret')]);
+		config(['services.mailgun.domain' => setting('mail.mail_mailgun_domain')]);
+		config(['services.mailgun.secret' => setting('mail.mail_mailgun_secret')]);
+		config(['services.mandrill.secret' => setting('mail.mail_mandrill_secret')]);
     }
 
     /**


### PR DESCRIPTION
### What does this implement or fix?
I can't overwrite some config value like user model class name in config/auth.php.

### Does this close any currently open issues?
- No