### PR TITLE
Fix field type not found error when build settings models

### DIFF
--- a/src/Console/Actions/SyncSettings.php
+++ b/src/Console/Actions/SyncSettings.php
@@ -194,7 +194,7 @@ class SyncSettings
     private function determineValidation($setting): array
     {
         if (!isset($setting['required'])) {
-            return [];
+            return ['value' => null];
         }
 
         return $setting['required'] === true ? ['value' => 'required'] : [];

--- a/src/Console/Actions/SyncSettings.php
+++ b/src/Console/Actions/SyncSettings.php
@@ -147,7 +147,7 @@ class SyncSettings
                     'help'       => $item['description'] ?? '',
                     'order'      => ++$order,
                     'validation' => $this->determineValidation($item),
-                    'settings'   => array_merge($fieldtype->getSettings(), [
+                    'settings'   => array_merge($fieldtype->getSettings(), ($item['settings'] ?? []), [
                         'default'   => $item['default'] ?? '',
                         'override'  => $item['override'] ?? false,
                         'options'   => $this->formatSettingOptions($item['options'] ?? []),

--- a/src/Console/Actions/SyncSettings.php
+++ b/src/Console/Actions/SyncSettings.php
@@ -193,11 +193,10 @@ class SyncSettings
      */
     private function determineValidation($setting): array
     {
-        if (!isset($setting['required'])) {
-            return ['value' => null];
+        if (isset($setting['required']) && $setting['required'] === true) {
+            return ['value' => 'required'];
         }
-
-        return $setting['required'] === true ? ['value' => 'required'] : [];
+        return ['value' => null];
     }
 
     /**

--- a/src/Http/Controllers/API/SettingController.php
+++ b/src/Http/Controllers/API/SettingController.php
@@ -65,6 +65,9 @@ class SettingController extends Controller
         foreach ($setting->blueprint->relationships() as $relationship) {
             $relationship->type()->persistRelationship($setting->settings, $relationship);
         }
+
+        // Let new setting to take effect after the value of setting is updated
+        cache()->flush();
     }
 
 

--- a/src/Providers/FusionServiceProvider.php
+++ b/src/Providers/FusionServiceProvider.php
@@ -156,10 +156,10 @@ class FusionServiceProvider extends ServiceProvider
      */
     private function registerProviders()
     {
+        $this->app->register(FieldtypeServiceProvider::class);
         $this->app->register(BladeServiceProvider::class);
         $this->app->register(ConfigServiceProvider::class);
         $this->app->register(EventServiceProvider::class);
-        $this->app->register(FieldtypeServiceProvider::class);
         $this->app->register(MenuServiceProvider::class);
         $this->app->register(SettingServiceProvider::class);
         $this->app->register(ThemeServiceProvider::class);


### PR DESCRIPTION
### What does this implement or fix?
`Fieldtype not found in registry. [select]` error occurred when `composer dumpautoload`

### Does this close any currently open issues?
- No

### Screenshots
Screenshots showcasing your update are helpful for reviewers (if its a visual UI update).

- [V] All javascript/scss resources are compiled for production