### PR TITLE
Fix filename issue when user save a file from fusion cms to their local

### DIFF
--- a/resources/views/forms/fields/file.blade.php
+++ b/resources/views/forms/fields/file.blade.php
@@ -6,7 +6,7 @@
     <input
     	type="file"
     	id="{{ $field->handle }}-field"
-    	name="{{ $field->handle }}[]"
+    	name="{{ $field->handle }}{{ $field->settings['multiple'] ? '[]' : ''}}"
     	accept="{{ $field->settings['accept'] ?? null }}"
     	{{ $field->settings['multiple'] ? 'multiple': null }}
     />

--- a/src/Fieldtypes/FileFieldtype.php
+++ b/src/Fieldtypes/FileFieldtype.php
@@ -93,6 +93,8 @@ class FileFieldtype extends Fieldtype
             $oldValues = $model->{$field->handle}->pluck('id');
             $newValues = collect();
 
+            $files = is_array($files) ? $files : [$files];
+
             foreach ($files as $key => $file) {
                 foreach ((array) $field->settings['directory'] as $data) {
                     /**

--- a/src/Fieldtypes/FileFieldtype.php
+++ b/src/Fieldtypes/FileFieldtype.php
@@ -116,6 +116,18 @@ class FileFieldtype extends Fieldtype
             // --
             $model->{$field->handle}()->detach($oldValues);
             $model->{$field->handle}()->attach($newValues);
+        } else if (request()->filled($field->handle)) {
+			$oldValues = isset($model->{$field->handle}) ? $model->{$field->handle}->pluck('id') : [];
+            $newValues = collect($value ?? request()->input($field->handle))
+            ->mapWithKeys(function ($value) use ($field) {
+                return [
+                    $value['id'] => [
+                        'field_id' => $field->id,
+                    ],
+                ];
+            });
+            $model->{$field->handle}()->wherePivot('field_id', $field->id)->detach($oldValues);
+            $model->{$field->handle}()->attach($newValues);
         }
     }
 

--- a/src/Http/Controllers/Web/FileController.php
+++ b/src/Http/Controllers/Web/FileController.php
@@ -32,7 +32,7 @@ class FileController extends Controller
 
         return Storage::disk($file->disk->handle)->response(
             $file->location,
-            $file->name,
+            $file->name.'.'.$file->extension,
             [
                 'Content-Type' => $file->mimetype,
             ]

--- a/src/Http/Controllers/Web/FileController.php
+++ b/src/Http/Controllers/Web/FileController.php
@@ -22,7 +22,7 @@ class FileController extends Controller
             return redirect()->to('/file/'.$uuid.'/'.$file->name.'?'.http_build_query($params));
         }
 
-        if (in_array($file->mimetype, ['image/jpeg', 'image/gif', 'image/png'])) {
+        if (in_array($file->mimetype, ['image/jpeg', 'image/gif', 'image/png', 'image/webp'])) {
             return $this->imageResponse($file, $params);
         }
 


### PR DESCRIPTION
### What does this implement or fix?
Fix issue where when user save a file from fusion cms to their local, the file will not have any extension name, and hence they might don't know how to open the file

### Does this close any currently open issues?
- No

- [x] All javascript/scss resources are compiled for production